### PR TITLE
Added consistent read option

### DIFF
--- a/src/etcd/client.py
+++ b/src/etcd/client.py
@@ -24,7 +24,7 @@ class Client(object):
     _MPOST = 'POST'
     _MDELETE = 'DELETE'
     _comparison_conditions = ['prevValue', 'prevIndex', 'prevExist']
-    _read_options = ['recursive', 'wait', 'waitIndex', 'sorted']
+    _read_options = ['recursive', 'wait', 'waitIndex', 'sorted', 'consistent']
 
     def __init__(
             self,


### PR DESCRIPTION
In a multi-node cluster, this ensures the returned value is consistent across
the cluster (per xiangli via IRC).
