### PR TITLE
Dont require pyOpenSSL unless we're on python 2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,8 +10,10 @@ version = '0.3.0'
 
 install_requires = [
     'urllib3==1.7',
-    'pyOpenSSL==0.13.1',
 ]
+
+if sys.version_info[0] == 2:
+    install_requires.append('pyOpenSSL==0.13.1')
 
 
 setup(name='python-etcd',


### PR DESCRIPTION
With python 3 pyOpenSSL is not really a strict requirement, and with python >= 3.3 it can be a pain to get pyOpenSSL installed on Windows. It would be nice if this requirement could be made python 2 only.
