### PR TITLE
Use newer PyOpenSSL

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ version = '0.3.0'
 
 install_requires = [
     'urllib3>=1.7',
-    'pyOpenSSL>=0.13.1',
+    'pyOpenSSL>=0.14',
 ]
 
 test_requires = [


### PR DESCRIPTION
The version of PyOpenSSL (0.13.1) has issues compiling, which means pip-accel can't install it. https://bugs.launchpad.net/pyopenssl/+bug/1266521
