### PR TITLE
Forward leaves_only value in get_subtree() recursive calls

### DIFF
--- a/src/etcd/__init__.py
+++ b/src/etcd/__init__.py
@@ -67,7 +67,7 @@ class EtcdResult(object):
             if not leaves_only:
                 #Return also dirs, not just value nodes
                 yield node
-            for child in node.children:
+            for child in node.get_subtree(leaves_only=leaves_only)::
                 yield child
         return
 


### PR DESCRIPTION
To be able to yield recursively dir nodes when needed
