### PR TITLE
Added recursive directory watch

### DIFF
--- a/docs-source/index.rst
+++ b/docs-source/index.rst
@@ -89,6 +89,29 @@ Get a key
     client.read('/nodes/n2', wait=True, waitIndex=10)
 
 
+Watch a key
+...........
+
+.. code-block:: python
+
+    # eternal_watch(key, index=None, recursive=False):
+    #
+    # The generator will yield changes from a key. 
+    # Note that this method will block forever until an event is generated.
+    # Equivalent shell command: etcdctl watch
+    #
+    # Arguments:
+    #    key (str):  Key to subcribe to.
+    #    index (int):  Index from where the changes will be received.
+    #    recursive (bool): Watch for updates on the hole directory.
+    # Yields:
+    #    client.EtcdResult
+    # Raises:
+    #    etcd.EtcdException If etcd closes the connection
+    
+    # Example
+    for event in client.eternal_watch('/subcription_key'):
+        print event.value
 
 Delete a key
 ............

--- a/src/etcd/client.py
+++ b/src/etcd/client.py
@@ -452,7 +452,7 @@ class Client(object):
         """
         return self.read(key)
 
-    def watch(self, key, index=None, timeout=None):
+    def watch(self, key, index=None, timeout=None, recursive=False):
         """
         Blocks until a new event has been received, starting at index 'index'
 
@@ -476,11 +476,11 @@ class Client(object):
 
         """
         if index:
-            return self.read(key, wait=True, waitIndex=index, timeout=timeout)
+            return self.read(key, wait=True, waitIndex=index, timeout=timeout, recursive=recursive)
         else:
-            return self.read(key, wait=True, timeout=timeout)
+            return self.read(key, wait=True, timeout=timeout, recursive=recursive)
 
-    def eternal_watch(self, key, index=None):
+    def eternal_watch(self, key, index=None, recursive=False):
         """
         Generator that will yield changes from a key.
         Note that this method will block forever until an event is generated.
@@ -488,6 +488,7 @@ class Client(object):
         Args:
             key (str):  Key to subcribe to.
             index (int):  Index from where the changes will be received.
+            recursive (bool): Watch for updates on the hole directory.  
 
         Yields:
             client.EtcdResult
@@ -501,7 +502,7 @@ class Client(object):
         """
         local_index = index
         while True:
-            response = self.watch(key, index=local_index, timeout=0)
+            response = self.watch(key, index=local_index, timeout=0, recursive=recursive)
             if local_index is not None:
                 local_index += 1
             yield response


### PR DESCRIPTION
This pull request enables watching a hole directory for updates. All i did was adding the parameter recursive.

Example: etcd_client.eternal_watch('acid', recursive=True)