### PR TITLE
Add payload to EtcdException and more elabrated Etcd exceptions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ python:
 
 before_install:
   - ./build_etcd.sh v0.3.0
+  - pip install --upgrade setuptools
 
 # command to install dependencies
 install: 

--- a/src/etcd/__init__.py
+++ b/src/etcd/__init__.py
@@ -173,12 +173,8 @@ class EtcdError(object):
         try:
             msg = '{} : {}'.format(message, cause)
             payload={'errorCode': errorCode, 'message': message, 'cause': cause}
-            print("============================")
-            print(payload)
-            print("length: {}".format(len(kwdargs)))
             if len(kwdargs) > 0:
                 for key in kwdargs:
-                    print("{}={}".format(key, kwdargs[key]))
                     payload[key]=kwdargs[key]
             exc = cls.error_exceptions[errorCode]
         except:

--- a/src/etcd/__init__.py
+++ b/src/etcd/__init__.py
@@ -105,7 +105,7 @@ class EtcdException(Exception):
     """
     Generic Etcd Exception.
     """
-    def __init__(self, message, payload=None):
+    def __init__(self, message=None, payload=None):
         super(Exception, self).__init__(message)
         self.payload=payload
 
@@ -171,7 +171,7 @@ class EtcdError(object):
     def handle(cls, errorCode=None, message=None, cause=None, **kwdargs):
         """ Decodes the error and throws the appropriate error message"""
         try:
-            msg = "{} : {}".format(message, cause)
+            msg = '{} : {}'.format(message, cause)
             payload={'errorCode': errorCode, 'message': message, 'cause': cause}
             if len(kwdargs) > 0:
                 for key, value in kwdargs.iteritems():

--- a/src/etcd/__init__.py
+++ b/src/etcd/__init__.py
@@ -173,9 +173,13 @@ class EtcdError(object):
         try:
             msg = '{} : {}'.format(message, cause)
             payload={'errorCode': errorCode, 'message': message, 'cause': cause}
+            print("============================")
+            print(payload)
+            print("length: {}".format(len(kwdargs)))
             if len(kwdargs) > 0:
-                for key, value in kwdargs.iteritems():
-                    payload[key]=value
+                for key in kwdargs:
+                    print("{}={}".format(key, kwdargs[key]))
+                    payload[key]=kwdargs[key]
             exc = cls.error_exceptions[errorCode]
         except:
             msg = "Unable to decode server response"

--- a/src/etcd/client.py
+++ b/src/etcd/client.py
@@ -202,7 +202,7 @@ class Client(object):
         try:
             self.get(key)
             return True
-        except KeyError:
+        except etcd.EtcdKeyNotFound:
             return False
 
     def _sanitize_key(self, key):

--- a/src/etcd/tests/integration/test_election.py
+++ b/src/etcd/tests/integration/test_election.py
@@ -31,4 +31,4 @@ class TestElection(test_simple.EtcdIntegrationTest):
         e.set('/mysql', name='foo', ttl=1)
         time.sleep(2)
         self.assertRaises(etcd.EtcdException, e.get, '/mysql')
-        self.assertRaises(KeyError, e.delete, '/mysql', name='foo')
+        self.assertRaises(etcd.EtcdKeyNotFound, e.delete, '/mysql', name='foo')

--- a/src/etcd/tests/integration/test_simple.py
+++ b/src/etcd/tests/integration/test_simple.py
@@ -120,7 +120,7 @@ class TestSimple(EtcdIntegrationTest):
         set_result = self.client.write('/subtree/test_set2', 'test-key3')
         get_result = self.client.read('/subtree', recursive=True)
         result = [subkey.value for subkey in get_result.leaves]
-        self.assertEquals(['test-key1', 'test-key2', 'test-key3'], result)
+        self.assertEquals(['test-key1', 'test-key2', 'test-key3'].sort(), result.sort())
 
     def test_directory_ttl_update(self):
         """ INTEGRATION: should be able to update a dir TTL """

--- a/src/etcd/tests/integration/test_simple.py
+++ b/src/etcd/tests/integration/test_simple.py
@@ -74,7 +74,7 @@ class TestSimple(EtcdIntegrationTest):
         try:
             get_result = self.client.get('/test_set')
             assert False
-        except KeyError as e:
+        except etcd.EtcdKeyNotFound as e:
             pass
 
         self.assertFalse('/test_set' in self.client)
@@ -100,7 +100,7 @@ class TestSimple(EtcdIntegrationTest):
         try:
             get_result = self.client.get('/test_set')
             assert False
-        except KeyError as e:
+        except etcd.EtcdKeyNotFound as e:
             pass
 
     def test_update(self):
@@ -140,7 +140,7 @@ class TestErrors(EtcdIntegrationTest):
         """ INTEGRATION: try to write  value to an existing directory """
 
         self.client.set('/directory/test-key', 'test-value')
-        self.assertRaises(KeyError, self.client.set, '/directory', 'test-value')
+        self.assertRaises(etcd.EtcdNotFile, self.client.set, '/directory', 'test-value')
 
     def test_test_and_set(self):
         """ INTEGRATION: try test_and_set operation """
@@ -159,7 +159,8 @@ class TestErrors(EtcdIntegrationTest):
         `prevExist=True` should fail """
         self.client.write('/mydir', None, dir=True)
 
-        self.assertRaises(KeyError, self.client.write, '/mydir', None, dir=True)
+        self.assertRaises(etcd.EtcdNotFile, self.client.write, '/mydir', None, dir=True)
+        self.assertRaises(etcd.EtcdAlreadyExist, self.client.write, '/mydir', None, dir=True, prevExist=False)
 
 
 class TestClusterFunctions(EtcdIntegrationTest):

--- a/src/etcd/tests/unit/test_old_request.py
+++ b/src/etcd/tests/unit/test_old_request.py
@@ -171,7 +171,7 @@ class TestClientRequest(unittest.TestCase):
     def test_not_in(self):
         """ Can check if key is not in client """
         client = etcd.Client()
-        client.get = mock.Mock(side_effect=KeyError())
+        client.get = mock.Mock(side_effect=etcd.EtcdKeyNotFound())
         result = '/testkey' not in client
         self.assertEquals(True, result)
 
@@ -307,8 +307,8 @@ class TestClientApiExecutor(unittest.TestCase):
         try:
             client.api_execute('/v2/keys/testkey', client._MGET)
             assert False
-        except KeyError as e:
-            self.assertEquals(str(e), "'message : cause'")
+        except etcd.EtcdKeyNotFound as e:
+            self.assertEquals(str(e), 'message : cause')
 
     def test_put(self):
         """ http put request """
@@ -357,8 +357,8 @@ class TestClientApiExecutor(unittest.TestCase):
         try:
             client.api_execute('/v2/keys/testkey', client._MPUT, payload)
             self.fail()
-        except KeyError as e:
-            self.assertEquals("'message : cause'", str(e))
+        except etcd.EtcdNotFile as e:
+            self.assertEquals('message : cause', str(e))
 
     def test_get_error_unknown(self):
         """ http get error request unknown """

--- a/src/etcd/tests/unit/test_request.py
+++ b/src/etcd/tests/unit/test_request.py
@@ -282,7 +282,7 @@ class TestClientApiInterface(TestClientApiBase):
 
     def test_not_in(self):
         """ Can check if key is not in client """
-        self._mock_exception(KeyError, 'Key not Found : /testKey')
+        self._mock_exception(etcd.EtcdKeyNotFound, 'Key not Found : /testKey')
         self.assertTrue('/testey' not in self.client)
 
     def test_in(self):


### PR DESCRIPTION
The following exception were added:
EtcdKeyError(EtcdException) - Generic Etcd key error
EtcdKeyNotFound(EtcdKeyError) - Etcd key not found (100)
EtcdNotFile(EtcdKeyError) - Etcd not a file (102)
EtcdNotDir(EtcdKeyError) - Etcd not a directory (104)
EtcdAlreadyExist(EtcdKeyError) - Etcd already exist (105)
EtcdEventIndexCleared(EtcdException) - Etcd event index is outdated and cleared (401)