### PR TITLE
Less dangerous delete() recursive kwarg

### DIFF
--- a/src/etcd/client.py
+++ b/src/etcd/client.py
@@ -347,7 +347,7 @@ class Client(object):
             self.key_endpoint + key, self._MGET, params=params, timeout=timeout)
         return self._result_from_response(response)
 
-    def delete(self, key, recursive=None, dir=None, **kwdargs):
+    def delete(self, key, recursive=False, dir=None, **kwdargs):
         """
         Removed a key from etcd.
 
@@ -379,8 +379,7 @@ class Client(object):
         key = self._sanitize_key(key)
 
         kwds = {}
-        if recursive is not None:
-            kwds['recursive'] = recursive and "true" or "false"
+        kwds['recursive'] = "true" if recursive else "false"
         if dir is not None:
             kwds['dir'] = dir and "true" or "false"
 


### PR DESCRIPTION
The client `delete()` method supports an optional "recursive" kwarg for recursive deletion. The current implementation defaults to None, and the code explicitly tests for None. If, for example, a False value is explicitly passed the "is not None" code path would run (although the next line would catch the fact the parameter is False). A clearer default would be False rather than None.
