### PR TITLE
Fix failure if client is connected with allow_reconnect to a proxy (new ...

### DIFF
--- a/src/etcd/client.py
+++ b/src/etcd/client.py
@@ -121,7 +121,9 @@ class Client(object):
             # we need the set of servers in the cluster in order to try
             # reconnecting upon error.
             self._machines_cache = self.machines
-            self._machines_cache.remove(self._base_uri)
+            if self._base_uri in self._machines_cache:
+                # this would fail if client is connected to a proxy
+                self._machines_cache.remove(self._base_uri)
         else:
             self._machines_cache = []
 


### PR DESCRIPTION
...feature of etcd 2.0)

  >>> from etcd import Client
  >>> c = Client(host="localhost", port=8080, allow_reconnect=True, allow_redirect=True)
  Traceback (most recent call last):
     File "<stdin>", line 1, in <module>
     File "etcd/client.py", line 124, in __init__
       self._machines_cache.remove(self._base_uri)
       ValueError: list.remove(x): x not in list


You can setup a local test cluster with proxy to reproduce the error:

etcd -name infra1 -listen-client-urls http://localhost:4001 \
  -advertise-client-urls http://localhost:4001 \
  -listen-peer-urls http://localhost:7001 \
  -initial-advertise-peer-urls http://localhost:7001 \
  -initial-cluster-token etcd-cluster-1 \
  -initial-cluster 'infra1=http://localhost:7001,infra2=http://localhost:7002,infra3=http://localhost:7003'\
  -initial-cluster-state new &
etcd -name infra2 -listen-client-urls http://localhost:4002 \
  -advertise-client-urls http://localhost:4002 \
  -listen-peer-urls http://localhost:7002 \
  -initial-advertise-peer-urls http://localhost:7002 \
  -initial-cluster-token etcd-cluster-1 \
  -initial-cluster 'infra1=http://localhost:7001,infra2=http://localhost:7002,infra3=http://localhost:7003' \
  -initial-cluster-state new &
etcd -name infra3 -listen-client-urls http://localhost:4003 \
  -advertise-client-urls http://localhost:4003 \
  -listen-peer-urls http://localhost:7003 \
  -initial-advertise-peer-urls http://localhost:7003 \
  -initial-cluster-token etcd-cluster-1 \
  -initial-cluster 'infra1=http://localhost:7001,infra2=http://localhost:7002,infra3=http://localhost:7003'\
  -initial-cluster-state new &
etcd -name proxy1 -proxy=on
  -bind-addr 127.0.0.1:8080 \
  -initial-cluster 'infra1=http://localhost:7001,infra2=http://localhost:7002,infra3=http://localhost:7003'