### PR TITLE
check if ttl is not None in write

### DIFF
--- a/src/etcd/client.py
+++ b/src/etcd/client.py
@@ -247,7 +247,7 @@ class Client(object):
         if value is not None:
             params['value'] = value
 
-        if ttl:
+        if ttl is not None:
             params['ttl'] = ttl
 
         if dir:


### PR DESCRIPTION
This resolves a bug where if you set the ttl=0, the ttl never gets
added.