### PR TITLE
Disable urllib3 retry when timeout is explicitly specified.

### DIFF
--- a/src/etcd/client.py
+++ b/src/etcd/client.py
@@ -580,8 +580,10 @@ class Client(object):
                     raise etcd.EtcdException(
                         'HTTP method {} not supported'.format(method))
 
-            except (urllib3.exceptions.MaxRetryError,
-                    urllib3.exceptions.ConnectionError):
+            except urllib3.exceptions.HTTPError as exc:
+                if 'timeout' in request_kwargs and \
+                   isinstance(exc, urllib3.exceptions.TimeoutError):
+                    raise
                 self._base_uri = self._next_server()
                 some_request_failed = True
 

--- a/src/etcd/client.py
+++ b/src/etcd/client.py
@@ -543,12 +543,15 @@ class Client(object):
 
         some_request_failed = False
         response = False
+        request_kwargs = {}
 
         if timeout is None:
             timeout = self.read_timeout
+        else:
+            request_kwargs['retries'] = False
 
-        if timeout == 0:
-            timeout = None
+        if timeout:
+            request_kwargs['timeout'] = timeout
 
         if not path.startswith('/'):
             raise ValueError('Path does not start with /')
@@ -561,23 +564,24 @@ class Client(object):
                     response = self.http.request(
                         method,
                         url,
-                        timeout=timeout,
                         fields=params,
-                        redirect=self.allow_redirect)
+                        redirect=self.allow_redirect,
+                        **request_kwargs)
 
                 elif (method == self._MPUT) or (method == self._MPOST):
                     response = self.http.request_encode_body(
                         method,
                         url,
                         fields=params,
-                        timeout=timeout,
                         encode_multipart=False,
-                        redirect=self.allow_redirect)
+                        redirect=self.allow_redirect,
+                        **request_kwargs)
                 else:
                     raise etcd.EtcdException(
                         'HTTP method {} not supported'.format(method))
 
-            except urllib3.exceptions.MaxRetryError:
+            except (urllib3.exceptions.MaxRetryError,
+                    urllib3.exceptions.ProtocolError):
                 self._base_uri = self._next_server()
                 some_request_failed = True
 

--- a/src/etcd/client.py
+++ b/src/etcd/client.py
@@ -581,7 +581,7 @@ class Client(object):
                         'HTTP method {} not supported'.format(method))
 
             except (urllib3.exceptions.MaxRetryError,
-                    urllib3.exceptions.ProtocolError):
+                    urllib3.exceptions.ConnectionError):
                 self._base_uri = self._next_server()
                 some_request_failed = True
 


### PR DESCRIPTION
This is to fix issue #81. 

By default urrlib3 retries 3 times on timeout, so in case of watch with specified timeout (if no changes happen):
1. 4 requests with the specified timeout are run.
2. Once they all timeout MaxRetryError is raised by urllib3.
3. This triggers retries on different servers
4. Finally the call fails with EtcdException('No more machines in the cluster'), after much longer than specified in timeout.

This patch disables urllib3 retry logic if timeout was explicitly specified by user. 
Since with retry disabled you can get any urllib3 error (instead of always getting MaxRetryError) now server-retry logic is bound to any urllib3 error unless it's a timeout error.