### PR TITLE
do not send parameters with `None` value to etcd

### DIFF
--- a/src/etcd/__init__.py
+++ b/src/etcd/__init__.py
@@ -160,6 +160,7 @@ class EtcdError(object):
         201: ValueError,
         202: ValueError,
         203: ValueError,
+        209: ValueError,
         300: Exception,
         301: Exception,
         400: Exception,

--- a/src/etcd/client.py
+++ b/src/etcd/client.py
@@ -338,7 +338,7 @@ class Client(object):
             if k in self._read_options:
                 if type(v) == bool:
                     params[k] = v and "true" or "false"
-                else:
+                elif v is not None:
                     params[k] = v
 
         timeout = kwdargs.get('timeout', None)


### PR DESCRIPTION
same problem with #87 

`watch` function will fail and cause
`etcd.EtcdException: Unable to decode server response` error.

the etcd server actually returns with this error response

{
    "errorCode": 209,
    "message": "Invalid field",
    "cause": "invalid value for \"recursive\"",
    "index": 0
}

to fix this, just skip setting query parameter when it's value is None.