### PR TITLE
Fix etcd.Client.machines

### DIFF
--- a/src/etcd/tests/unit/test_client.py
+++ b/src/etcd/tests/unit/test_client.py
@@ -79,3 +79,21 @@ class TestClient(unittest.TestCase):
             port=4003,
             protocol='https')
         assert client.base_uri == 'https://192.168.1.1:4003'
+
+    def test_set_use_proxies(self):
+        """ can set the use_proxies flag """
+        client = etcd.Client(use_proxies = True)
+        assert client._use_proxies
+
+    def test_allow_reconnect(self):
+        """ Fails if allow_reconnect is false and a list of hosts is given"""
+        with self.assertRaises(etcd.EtcdException):
+            etcd.Client(
+                host=(('localhost', 4001), ('localhost', 4002)),
+            )
+        # This doesn't raise an exception
+        client = etcd.Client(
+            host=(('localhost', 4001), ('localhost', 4002)),
+            allow_reconnect=True,
+            use_proxies=True,
+        )

--- a/src/etcd/tests/unit/test_old_request.py
+++ b/src/etcd/tests/unit/test_old_request.py
@@ -19,23 +19,6 @@ class FakeHTTPResponse(object):
 
 class TestClientRequest(unittest.TestCase):
 
-    def test_machines(self):
-        """ Can request machines """
-        client = etcd.Client()
-        client.api_execute = mock.Mock(
-            return_value=FakeHTTPResponse(200, data=
-                                          "http://127.0.0.1:4002,"
-                                          " http://127.0.0.1:4001,"
-                                          " http://127.0.0.1:4003,"
-                                          " http://127.0.0.1:4001")
-        )
-
-        assert client.machines == [
-            'http://127.0.0.1:4002',
-            'http://127.0.0.1:4001',
-            'http://127.0.0.1:4003',
-            'http://127.0.0.1:4001'
-        ]
 
     def test_leader(self):
         """ Can request the leader """

--- a/src/etcd/tests/unit/test_request.py
+++ b/src/etcd/tests/unit/test_request.py
@@ -105,13 +105,13 @@ class TestClientApiInterface(TestClientApiBase):
 
     If a test should be run only in this class, please override the method there.
     """
-
-    def test_machines(self):
+    @mock.patch('urllib3.request.RequestMethods.request')
+    def test_machines(self, mocker):
         """ Can request machines """
         data = ['http://127.0.0.1:4001',
                 'http://127.0.0.1:4002', 'http://127.0.0.1:4003']
         d = ','.join(data)
-        self._mock_api(200, d)
+        mocker.return_value = self._prepare_response(200, d)
         self.assertEquals(data, self.client.machines)
 
     def test_leader(self):


### PR DESCRIPTION
In our old version of the code, etcd.Client.api_execute called
Client.machines in case of failure, which called api_execute in
return. In the scenario of a client with a list of possible servers, and
the first of the list being down, we throw an exception right now,
because of this.

Using directly urllib3 and skipping api_execute in Client.machines
allows us to connect to the first available server.

Closes #51