### PR TITLE
Check cluster ID hasn't changed on each request

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,7 @@
 The MIT License (MIT)
 
 Copyright (c) 2013 Jose Plana Mario
+Modifications, Copyright (c) 2015 Metaswitch Networks Limited
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/src/etcd/__init__.py
+++ b/src/etcd/__init__.py
@@ -110,6 +110,15 @@ class EtcdException(Exception):
         self.payload=payload
 
 
+class EtcdClusterIdChanged(EtcdException):
+    """
+    The etcd cluster ID changed.  This may indicate the cluster was replaced
+    with a backup.  Raised to prevent waiting on an etcd_index that was only
+    valid on the old cluster.
+    """
+    pass
+
+
 class EtcdKeyError(EtcdException):
     """
     Etcd Generic KeyError Exception

--- a/src/etcd/tests/unit/test_old_request.py
+++ b/src/etcd/tests/unit/test_old_request.py
@@ -10,12 +10,18 @@ from etcd import EtcdException
 
 class FakeHTTPResponse(object):
 
-    def __init__(self, status, data=''):
+    def __init__(self, status, data='', headers=None):
         self.status = status
         self.data = data.encode('utf-8')
+        self.headers = headers or {
+            "x-etcd-cluster-id": "abdef12345",
+        }
 
     def getheaders(self):
-        return {}
+        return self.headers
+
+    def getheader(self, header):
+        return self.headers[header]
 
 class TestClientRequest(unittest.TestCase):
 

--- a/src/etcd/tests/unit/test_request.py
+++ b/src/etcd/tests/unit/test_request.py
@@ -16,7 +16,7 @@ class TestClientApiBase(unittest.TestCase):
     def setUp(self):
         self.client = etcd.Client()
 
-    def _prepare_response(self, s, d):
+    def _prepare_response(self, s, d, cluster_id=None):
         if isinstance(d, dict):
             data = json.dumps(d).encode('utf-8')
         else:
@@ -25,10 +25,11 @@ class TestClientApiBase(unittest.TestCase):
         r = mock.create_autospec(urllib3.response.HTTPResponse)()
         r.status = s
         r.data = data
+        r.getheader.return_value = cluster_id or "abcd1234"
         return r
 
-    def _mock_api(self, status, d):
-        resp = self._prepare_response(status, d)
+    def _mock_api(self, status, d, cluster_id=None):
+        resp = self._prepare_response(status, d, cluster_id=cluster_id)
         self.client.api_execute = mock.create_autospec(
             self.client.api_execute, return_value=resp)
 
@@ -96,7 +97,6 @@ class TestClientApiInternals(TestClientApiBase):
         self.client.write('/newdir', None, dir=True)
         self.assertEquals(self.client.api_execute.call_args,
             (('/v2/keys/newdir', 'PUT'), dict(params={'dir': 'true'})))
-
 
 
 class TestClientApiInterface(TestClientApiBase):
@@ -463,10 +463,11 @@ class EtcdLockTestCase(TestClientApiBase):
 class TestClientRequest(TestClientApiInterface):
 
     def setUp(self):
-        self.client = etcd.Client()
+        self.client = etcd.Client(expected_cluster_id="abcdef1234")
 
-    def _mock_api(self, status, d):
+    def _mock_api(self, status, d, cluster_id=None):
         resp = self._prepare_response(status, d)
+        resp.getheader.return_value = cluster_id or "abcdef1234"
         self.client.http.request_encode_body = mock.create_autospec(
             self.client.http.request_encode_body, return_value=resp
         )
@@ -474,11 +475,13 @@ class TestClientRequest(TestClientApiInterface):
             self.client.http.request, return_value=resp
         )
 
-    def _mock_error(self, error_code, msg, cause, method='PUT', fields=None):
+    def _mock_error(self, error_code, msg, cause, method='PUT', fields=None,
+                    cluster_id=None):
         resp = self._prepare_response(
             500,
             {'errorCode': error_code, 'message': msg, 'cause': cause}
         )
+        resp.getheader.return_value = cluster_id or "abcdef1234"
         self.client.http.request_encode_body = mock.create_autospec(
             self.client.http.request_encode_body, return_value=resp
         )
@@ -507,6 +510,12 @@ class TestClientRequest(TestClientApiInterface):
         """ Exception will be raised if an unsupported HTTP method is used """
         self.assertRaises(etcd.EtcdException,
                           self.client.api_execute, '/testpath/bar', 'TRACE')
+
+    def test_read_cluster_id_changed(self):
+        """ Read timeout set to the default """
+        self._mock_api(200, {}, cluster_id="notabcd1234")
+        self.assertRaises(etcd.EtcdClusterIdChanged,
+                          self.client.read, '/testkey')
 
     def test_not_in(self):
         pass

--- a/src/etcd/tests/unit/test_request.py
+++ b/src/etcd/tests/unit/test_request.py
@@ -513,9 +513,19 @@ class TestClientRequest(TestClientApiInterface):
 
     def test_read_cluster_id_changed(self):
         """ Read timeout set to the default """
-        self._mock_api(200, {}, cluster_id="notabcd1234")
+        d = {u'action': u'set',
+             u'node': {
+                u'expiration': u'2013-09-14T00:56:59.316195568+02:00',
+                u'modifiedIndex': 6,
+                u'key': u'/testkey',
+                u'ttl': 19,
+                u'value': u'test'
+                }
+             }
+        self._mock_api(200, d, cluster_id="notabcd1234")
         self.assertRaises(etcd.EtcdClusterIdChanged,
                           self.client.read, '/testkey')
+        self.client.read("/testkey")
 
     def test_not_in(self):
         pass


### PR DESCRIPTION
This catches the case where the cluster is rebuilt from a backup
or replaced unexpectedly.  Without this change, we'd potentially
watch on an etcd index that was only valid on the old cluster.

* On read, record the cluster ID of the server.  We have to defer loading of
  the resource so we can check the headers before blocking on a
  watch.
* On watch, check the cluster ID hasn't changed.
