### PR TITLE
Make error handling more robust

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,7 @@
 The MIT License (MIT)
 
 Copyright (c) 2013 Jose Plana Mario
+Modifications, Copyright (c) 2015 Metaswitch Networks Limited
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/src/etcd/__init__.py
+++ b/src/etcd/__init__.py
@@ -107,7 +107,21 @@ class EtcdException(Exception):
     """
     def __init__(self, message=None, payload=None):
         super(Exception, self).__init__(message)
-        self.payload=payload
+        self.payload = payload
+
+
+class EtcdValueError(EtcdException, ValueError):
+    """
+    Base class for Etcd value-related errors.
+    """
+    pass
+
+
+class EtcdCompareFailed(EtcdValueError):
+    """
+    Compare-and-swap failure
+    """
+    pass
 
 
 class EtcdKeyError(EtcdException):
@@ -116,11 +130,13 @@ class EtcdKeyError(EtcdException):
     """
     pass
 
+
 class EtcdKeyNotFound(EtcdKeyError):
     """
     Etcd key not found exception (100)
     """
     pass
+
 
 class EtcdNotFile(EtcdKeyError):
     """
@@ -128,11 +144,13 @@ class EtcdNotFile(EtcdKeyError):
     """
     pass
 
+
 class EtcdNotDir(EtcdKeyError):
     """
     Etcd not a directory exception (104)
     """
     pass
+
 
 class EtcdAlreadyExist(EtcdKeyError):
     """
@@ -140,48 +158,88 @@ class EtcdAlreadyExist(EtcdKeyError):
     """
     pass
 
+
 class EtcdEventIndexCleared(EtcdException):
     """
     Etcd event index is outdated and cleared exception (401)
     """
     pass
 
+
+class EtcdWatcherCleared(EtcdException):
+    """
+    Watcher is cleared due to etcd recovery.
+    """
+    pass
+
+
+class EtcdLeaderElectionInProgress(EtcdException):
+    """
+    Request failed due to in-progress leader election.
+    """
+    pass
+
+
+class EtcdRootReadOnly(EtcdKeyError):
+    """
+    Operation is not valid on the root, which is read only.
+    """
+    pass
+
+
+class EtcdDirNotEmpty(EtcdValueError):
+    """
+    Directory not empty.
+    """
+    pass
+
+
 class EtcdError(object):
     # See https://github.com/coreos/etcd/blob/master/Documentation/errorcode.md
     error_exceptions = {
         100: EtcdKeyNotFound,
-        101: ValueError,
+        101: EtcdCompareFailed,
         102: EtcdNotFile,
-        103: Exception,
+        # 103: Non-public: no more peers.
         104: EtcdNotDir,
         105: EtcdAlreadyExist,
-        106: KeyError,
-        200: ValueError,
-        201: ValueError,
-        202: ValueError,
-        203: ValueError,
-        209: ValueError,
-        300: Exception,
-        301: Exception,
-        400: Exception,
+        # 106: Non-public: key is preserved.
+        107: EtcdRootReadOnly,
+        108: EtcdDirNotEmpty,
+        # 109: Non-public: existing peer addr.
+
+        200: EtcdValueError,
+        201: EtcdValueError,
+        202: EtcdValueError,
+        203: EtcdValueError,
+        204: EtcdValueError,
+        205: EtcdValueError,
+        206: EtcdValueError,
+        207: EtcdValueError,
+        208: EtcdValueError,
+        209: EtcdValueError,
+        210: EtcdValueError,
+
+        # 300: Non-public: Raft internal error.
+        301: EtcdLeaderElectionInProgress,
+
+        400: EtcdWatcherCleared,
         401: EtcdEventIndexCleared,
-        500: EtcdException
     }
 
     @classmethod
-    def handle(cls, errorCode=None, message=None, cause=None, **kwdargs):
-        """ Decodes the error and throws the appropriate error message"""
-        try:
-            msg = '{} : {}'.format(message, cause)
-            payload={'errorCode': errorCode, 'message': message, 'cause': cause}
-            if len(kwdargs) > 0:
-                for key in kwdargs:
-                    payload[key]=kwdargs[key]
-            exc = cls.error_exceptions[errorCode]
-        except:
-            msg = "Unable to decode server response"
-            exc = EtcdException
-        if exc in [EtcdException, EtcdKeyNotFound, EtcdNotFile, EtcdNotDir, EtcdAlreadyExist, EtcdEventIndexCleared]:
+    def handle(cls, payload):
+        """
+        Decodes the error and throws the appropriate error message
+
+        :param payload: The decoded JSON error payload as a dict.
+        """
+        error_code = payload.get("errorCode")
+        message = payload.get("message")
+        cause = payload.get("cause")
+        msg = '{} : {}'.format(message, cause)
+        exc = cls.error_exceptions.get(error_code, EtcdException)
+        if issubclass(exc, EtcdException):
             raise exc(msg, payload)
         else:
             raise exc(msg)

--- a/src/etcd/client.py
+++ b/src/etcd/client.py
@@ -630,9 +630,8 @@ class Client(object):
             # throw the appropriate exception
             try:
                 r = json.loads(resp)
-            except ValueError:
-                r = None
-            if r:
-                etcd.EtcdError.handle(**r)
-            else:
-                raise etcd.EtcdException(resp)
+            except (TypeError, ValueError):
+                # Bad JSON, make a response locally.
+                r = {"message": "Bad response",
+                     "cause": str(resp)}
+            etcd.EtcdError.handle(r)

--- a/src/etcd/tests/unit/test_old_request.py
+++ b/src/etcd/tests/unit/test_old_request.py
@@ -315,21 +315,7 @@ class TestClientApiExecutor(unittest.TestCase):
         except ValueError as e:
             self.assertEquals('message : cause', str(e))
 
-    def test_set_error(self):
-        """ http post error request 102 """
-        client = etcd.Client()
-        response = FakeHTTPResponse(
-            status=400,
-            data='{"message": "message", "cause": "cause", "errorCode": 102}')
-        client.http.request_encode_body = mock.Mock(return_value=response)
-        payload = {'value': 'value', 'prevValue': 'oldValue', 'ttl': '60'}
-        try:
-            client.api_execute('/v2/keys/testkey', client._MPUT, payload)
-            self.fail()
-        except KeyError as e:
-            self.assertEquals('message : cause', str(e))
-
-    def test_set_error(self):
+    def test_set_not_file_error(self):
         """ http post error request 102 """
         client = etcd.Client()
         response = FakeHTTPResponse(
@@ -348,23 +334,27 @@ class TestClientApiExecutor(unittest.TestCase):
         client = etcd.Client()
         response = FakeHTTPResponse(status=400,
                                     data='{"message": "message",'
-                                    ' "cause": "cause",'
-                                    ' "errorCode": 42}')
+                                         ' "cause": "cause",'
+                                         ' "errorCode": 42}')
         client.http.request = mock.Mock(return_value=response)
         try:
             client.api_execute('/v2/keys/testkey', client._MGET)
             self.fail()
         except etcd.EtcdException as e:
-            self.assertTrue(
-                str(e).startswith("Unable to decode server response"))
+            self.assertEqual(str(e), "message : cause")
 
     def test_get_error_request_invalid(self):
         """ http get error request invalid """
         client = etcd.Client()
-        response = FakeHTTPResponse(status=200,
-                                    data='{){){)*garbage*')
+        response = FakeHTTPResponse(status=400,
+                                    data='{)*garbage')
         client.http.request = mock.Mock(return_value=response)
-        self.assertRaises(etcd.EtcdException, client.get, '/testkey')
+        try:
+            client.api_execute('/v2/keys/testkey', client._MGET)
+            self.fail()
+        except etcd.EtcdException as e:
+            self.assertEqual(str(e),
+                             "Bad response : {)*garbage")
 
     def test_get_error_invalid(self):
         """ http get error request invalid """


### PR DESCRIPTION
* Add in missing exception types.
* Report the bad data on a parse error.
* Handle `TypeError` from `json.loads()` in case response is None.