### PR TITLE
Add logging, clean up some exception handling.

### DIFF
--- a/src/etcd/__init__.py
+++ b/src/etcd/__init__.py
@@ -1,7 +1,20 @@
-import collections
+import logging
 from .client import Client
 from .lock import Lock
 from .election import LeaderElection
+
+_log = logging.getLogger(__name__)
+
+# Prevent "no handler" warnings to stderr in projects that do not configure
+# logging.
+try:
+    from logging import NullHandler
+except ImportError:
+    # Python <2.7, just define it.
+    class NullHandler(logging.Handler):
+        def emit(self, record):
+            pass
+_log.addHandler(NullHandler())
 
 
 class EtcdResult(object):
@@ -145,6 +158,14 @@ class EtcdEventIndexCleared(EtcdException):
     Etcd event index is outdated and cleared exception (401)
     """
     pass
+
+
+class EtcdConnectionFailed(EtcdException):
+    """
+    Connection to etcd failed.
+    """
+    pass
+
 
 class EtcdError(object):
     # See https://github.com/coreos/etcd/blob/master/Documentation/errorcode.md

--- a/src/etcd/client.py
+++ b/src/etcd/client.py
@@ -7,7 +7,12 @@
 
 """
 import logging
-import httplib
+try:
+    # Python 3
+    from http.client import HTTPException
+except ImportError:
+    # Python 2
+    from httplib import HTTPException
 import socket
 import urllib3
 import json
@@ -210,7 +215,7 @@ class Client(object):
             _log.debug("Retrieved list of machines: %s", machines)
             return machines
         except (urllib3.exceptions.HTTPError,
-                httplib.HTTPException,
+                HTTPException,
                 socket.error) as e:
             # We can't get the list of machines, if one server is in the
             # machines cache, try on it
@@ -648,7 +653,7 @@ class Client(object):
             # urllib3 doesn't wrap all httplib exceptions and earlier versions
             # don't wrap socket errors either.
             except (urllib3.exceptions.HTTPError,
-                    httplib.HTTPException,
+                    HTTPException,
                     socket.error) as e:
                 _log.error("Request to server %s failed: %r",
                            self._base_uri, e)

--- a/src/etcd/tests/integration/test_simple.py
+++ b/src/etcd/tests/integration/test_simple.py
@@ -217,7 +217,8 @@ class TestClusterFunctions(EtcdIntegrationTest):
         self.processHelper.run(number=3)
         self.client = etcd.Client(port=6001, allow_reconnect=False)
         self.processHelper.kill_one(0)
-        self.assertRaises(etcd.EtcdException, self.client.get, '/test_set')
+        self.assertRaises(etcd.EtcdConnectionFailed, self.client.get,
+                          '/test_set')
 
     def test_reconnet_fails(self):
         """ INTEGRATION: fails to reconnect if no available machines """
@@ -487,8 +488,8 @@ class TestAuthenticatedAccess(EtcdIntegrationTest):
         client = etcd.Client(
             protocol='https', port=6001, ca_cert=self.ca2_cert_path)
 
-        self.assertRaises(urllib3.exceptions.SSLError, client.set, '/test-set', 'test-key')
-        self.assertRaises(urllib3.exceptions.SSLError, client.get, '/test-set')
+        self.assertRaises(etcd.EtcdConnectionFailed, client.set, '/test-set', 'test-key')
+        self.assertRaises(etcd.EtcdConnectionFailed, client.get, '/test-set')
 
     def test_get_set_authenticated(self):
         """ INTEGRATION: set/get a new value authenticated """


### PR DESCRIPTION
This pull request primarily adds logging to python-etcd.  

However, while I was writing it, I spotted that some of the exception handling appeared to be incorrect: only certain urllib3 and httplib exceptions were triggering a reconnect to another server in the cluster.  I cleaned that up while I was adding the logging.  Please correct me if I've misinterpreted the expected exception-handling behaviour!

The NullHandler idea is recommended here as a good way to prevent spurious output if the user isn't expecting your library to log:  https://lukasa.co.uk/2014/05/A_Brief_Digression_About_Logging/

Fixes #32.