### PR TITLE
inject pyopenssl into urllib3

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -3,9 +3,10 @@ parts = python
       sphinxbuilder
       test
 develop = .
-eggs = 
+eggs =
      urllib3==1.7
      pyOpenSSL==0.13.1
+     ndg-httpsclient==0.4.0
 
 [python]
 recipe = zc.recipe.egg

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@ version = '0.3.3'
 install_requires = [
     'urllib3>=1.7',
     'pyOpenSSL>=0.14',
+    'ndg-httpsclient>=0.4.0',
 ]
 
 test_requires = [

--- a/src/etcd/client.py
+++ b/src/etcd/client.py
@@ -14,11 +14,15 @@ except ImportError:
     # Python 2
     from httplib import HTTPException
 import socket
-import urllib3
-import urllib3.util
 import json
 import ssl
 import etcd
+
+# Fix InsecurePlatformWarning for Python < 2.7.9
+import urllib3
+import urllib3.util
+import urllib3.contrib.pyopenssl
+urllib3.contrib.pyopenssl.inject_into_urllib3()
 
 try:
     from urlparse import urlparse


### PR DESCRIPTION
This fixes an error where clients running less than Python 2.7.9 will
receive a InsecurePlatformWarning when attempting to connect to an etcd
server using SSL.