### PR TITLE
Add srv record-based DNS discovery.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,8 @@ before_install:
 
 # command to install dependencies
 install: 
-  - python bootstrap.py
+  - if [[ $TRAVIS_PYTHON_VERSION == 2* ]]; then python bootstrap.py; fi;
+  - if [[ $TRAVIS_PYTHON_VERSION == 3* ]]; then python bootstrap.py -c buildout3.cfg; fi;
   - bin/buildout
 
 # command to run tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 language: python
 python:
   - "2.7"
-  - "3.3"
+  - "3.5"
 
 before_install:
-  - ./build_etcd.sh v2.0.10
+  - ./build_etcd.sh v2.2.0
   - pip install --upgrade setuptools
 
 # command to install dependencies

--- a/README.rst
+++ b/README.rst
@@ -41,6 +41,8 @@ Create a client object
     client = etcd.Client(port=4002)
     client = etcd.Client(host='127.0.0.1', port=4003)
     client = etcd.Client(host='127.0.0.1', port=4003, allow_redirect=False) # wont let you run sensitive commands on non-leader machines, default is true
+    # If you have defined a SRV record for _etcd._tcp.example.com pointing to the clients
+    client = etcd.Client(srv_domain='example.com', protocol="https")
     # create a client against https://api.example.com:443/etcd
     client = etcd.Client(host='api.example.com', protocol='https', port=443, version_prefix='/etcd')
 Write a key

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -6,6 +6,7 @@ develop = .
 eggs = 
      urllib3==1.7
      pyOpenSSL==0.13.1
+     dnspython==1.12.0
 
 [python]
 recipe = zc.recipe.egg

--- a/buildout3.cfg
+++ b/buildout3.cfg
@@ -1,0 +1,24 @@
+[buildout]
+parts = python
+      sphinxbuilder
+      test
+develop = .
+eggs = 
+     urllib3==1.7
+     pyOpenSSL==0.13.1
+     dnspython3==1.12.0
+
+[python]
+recipe = zc.recipe.egg
+interpreter = python
+eggs = ${buildout:eggs}
+
+[test]
+recipe = pbp.recipe.noserunner
+eggs = ${python:eggs}
+     mock
+
+[sphinxbuilder]
+recipe = collective.recipe.sphinxbuilder
+source = ${buildout:directory}/docs-source
+build = ${buildout:directory}/docs

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,8 @@ NEWS = open(os.path.join(here, 'NEWS.txt')).read()
 version = '0.4.1'
 
 install_requires = [
-    'urllib3>=1.7'
+    'urllib3>=1.7',
+    'dnspython'
 ]
 
 test_requires = [

--- a/setup.py
+++ b/setup.py
@@ -8,9 +8,15 @@ NEWS = open(os.path.join(here, 'NEWS.txt')).read()
 
 version = '0.4.1'
 
+# Dnspython is two different packages depending on python version
+if sys.version_info.major == 2:
+    dns = 'dnspython'
+else:
+    dns = 'dnspython3'
+
 install_requires = [
     'urllib3>=1.7',
-    'dnspython'
+    dns
 ]
 
 test_requires = [

--- a/src/etcd/client.py
+++ b/src/etcd/client.py
@@ -111,8 +111,6 @@ class Client(object):
                 _log.error("Could not discover the etcd hosts from %s: %s",
                            srv_domain, e)
 
-        _log.debug("New etcd client created for %s:%s%s",
-                   host, port, version_prefix)
         self._protocol = protocol
 
         def uri(protocol, host, port):
@@ -166,6 +164,8 @@ class Client(object):
 
         self.http = urllib3.PoolManager(num_pools=10, **kw)
 
+        _log.debug("New etcd client created for %s", self.base_uri)
+
         if self._allow_reconnect:
             # we need the set of servers in the cluster in order to try
             # reconnecting upon error. The cluster members will be
@@ -194,6 +194,7 @@ class Client(object):
         for answer in answers:
             hosts.append(
                 (answer.target.to_text(omit_final_dot=True), answer.port))
+        _log.debug("Found %s", hosts)
         if not len(hosts):
             raise ValueError("The SRV record is present but no host were found")
         return tuple(hosts)


### PR DESCRIPTION
We use the same keys used by
confd (https://github.com/kelseyhightower/confd) to allow service
discovery via DNS.

@jplana @fasaxc I think this is very useful for whoever uses confd as well, and in general. It introduces a dependency on dnspython, but it's well packaged in all distros. What do you think?