### PR TITLE
Add a client-side locking implementation

### DIFF
--- a/src/etcd/__init__.py
+++ b/src/etcd/__init__.py
@@ -1,5 +1,6 @@
 import logging
 from .client import Client
+from .lock import Lock
 
 _log = logging.getLogger(__name__)
 
@@ -221,6 +222,11 @@ class EtcdDirNotEmpty(EtcdValueError):
     Directory not empty.
     """
     pass
+
+class EtcdLockExpired(EtcdException):
+    """
+    Our lock apparently expired while we were trying to acquire it.
+    """
 
 
 class EtcdError(object):

--- a/src/etcd/lock.py
+++ b/src/etcd/lock.py
@@ -1,0 +1,175 @@
+import logging
+import etcd
+import uuid
+
+_log = logging.getLogger(__name__)
+
+class Lock(object):
+    """
+    Locking recipe for etcd, inspired by the kazoo recipe for zookeeper
+    """
+
+    def __init__(self, client, lock_name):
+        self.client = client
+        self.name = lock_name
+        # props to Netflix Curator for this trick. It is possible for our
+        # create request to succeed on the server, but for a failure to
+        # prevent us from getting back the full path name. We prefix our
+        # lock name with a uuid and can check for its presence on retry.
+        self._uuid = uuid.uuid4().hex
+        self.path = "/_locks/{}".format(lock_name)
+        self.is_taken = False
+        self._sequence = None
+        _log.debug("Initiating lock for %s with uuid %s", self.path, self._uuid)
+
+    @property
+    def uuid(self):
+        """
+        The unique id of the lock
+        """
+        return self._uuid
+
+    @uuid.setter
+    def set_uuid(self, value):
+        old_uuid = self._uuid
+        self._uuid = value
+        if not self._find_lock():
+            _log.warn("The hand-set uuid was not found, refusing")
+            self._uuid = old_uuid
+            raise ValueError("Inexistent UUID")
+
+    @property
+    def is_acquired(self):
+        """
+        tells us if the lock is acquired
+        """
+        if not self.is_taken:
+            _log.debug("Lock not taken")
+            return False
+        try:
+            self.client.read(self.lock_key)
+            return True
+        except etcd.EtcdKeyNotFound:
+            _log.warn("Lock was supposedly taken, but we cannot find it")
+            self.is_taken = False
+            return False
+
+    def acquire(self, blocking=True, lock_ttl=3600, timeout=None):
+        """
+        Acquire the lock.
+
+        :param blocking Block until the lock is obtained, or timeout is reached
+        :param lock_ttl The duration of the lock we acquired, set to None for eternal locks
+        :param timeout The time to wait before giving up on getting a lock
+        """
+        # First of all try to write, if our lock is not present.
+        if not self._find_lock():
+            _log.debug("Lock not found, writing it to %s", self.path)
+            res = self.client.write(self.path, self.uuid, ttl=lock_ttl, append=True)
+            self._set_sequence(res.key)
+            _log.debug("Lock key %s written, sequence is %s", res.key, self._sequence)
+        elif lock_ttl:
+            # Renew our lock if already here!
+            self.client.write(self.lock_key, self.uuid, ttl=lock_ttl)
+
+        # now get the owner of the lock, and the next lowest sequence
+        return self._acquired(blocking=blocking, timeout=timeout)
+
+    def release(self):
+        """
+        Release the lock
+        """
+        if not self._sequence:
+            self._find_lock()
+        try:
+            _log.debug("Releasing existing lock %s", self.lock_key)
+            self.client.delete(self.lock_key)
+        except etcd.EtcdKeyNotFound:
+            _log.info("Lock %s not found, nothing to release", self.lock_key)
+            pass
+        finally:
+            self.is_taken = False
+
+    def __enter__(self):
+        """
+        You can use the lock as a contextmanager
+        """
+        self.acquire(blocking=True, lock_ttl=0)
+
+    def __exit__(self, type, value, traceback):
+        self.release()
+
+    def _acquired(self, blocking=True, timeout=None):
+        locker, nearest = self._get_locker()
+        self.is_taken = False
+        if self.lock_key == locker:
+            _log.debug("Lock acquired!")
+            # We own the lock, yay!
+            self.is_taken = True
+            return True
+        else:
+            self.is_taken = False
+            if not blocking:
+                return False
+            # Let's look for the lock
+            watch_key = nearest
+            _log.debug("Lock not acquired, now watching %s", watch_key)
+            t = max(0, timeout)
+            while True:
+                try:
+                    r = self.client.watch(watch_key, timeout=t)
+                    _log.debug("Detected variation for %s: %s", r.key, r.action)
+                    return self._acquired(blocking=True, timeout=timeout)
+                except etcd.EtcdKeyNotFound:
+                    _log.debug("Key %s not present anymore, moving on", watch_key)
+                    return self._acquired(blocking=True, timeout=timeout)
+                except etcd.EtcdException:
+                    # TODO: log something...
+                    pass
+
+    @property
+    def lock_key(self):
+        if not self._sequence:
+            raise ValueError("No sequence present.")
+        return self.path + '/' + str(self._sequence)
+
+    def _set_sequence(self, key):
+        self._sequence = int(key.replace(self.path, '').lstrip('/'))
+
+    def _find_lock(self):
+        if self._sequence:
+            try:
+                res = self.client.read(self.lock_key)
+                self._uuid = res.value
+                return True
+            except etcd.EtcdKeyNotFound:
+                return False
+        elif self._uuid:
+            try:
+                for r in self.client.read(self.path, recursive=True).leaves:
+                    if r.value == self._uuid:
+                        self._set_sequence(r.key)
+                        return True
+            except etcd.EtcdKeyNotFound:
+                pass
+        return False
+
+    def _get_locker(self):
+        results = [res for res in
+                   self.client.read(self.path, recursive=True).leaves]
+        if not self._sequence:
+            self._find_lock()
+        l = sorted([r.key for r in results])
+        _log.debug("Lock keys found: %s", l)
+        try:
+            i = l.index(self.lock_key)
+            if i == 0:
+                _log.debug("No key before our one, we are the locker")
+                return (l[0], None)
+            else:
+                _log.debug("Locker: %s, key to watch: %s", l[0], l[i-1])
+                return (l[0], l[i-1])
+        except ValueError:
+            # Something very wrong is going on, most probably
+            # our lock has expired
+            raise etcd.EtcdLockExpired(u"Lock not found")

--- a/src/etcd/tests/unit/__init__.py
+++ b/src/etcd/tests/unit/__init__.py
@@ -1,2 +1,34 @@
-from . import test_client
-from . import test_request
+import etcd
+import unittest
+import urllib3
+import json
+try:
+    import mock
+except ImportError:
+    from unittest import mock
+
+
+class TestClientApiBase(unittest.TestCase):
+
+    def setUp(self):
+        self.client = etcd.Client()
+
+    def _prepare_response(self, s, d, cluster_id=None):
+        if isinstance(d, dict):
+            data = json.dumps(d).encode('utf-8')
+        else:
+            data = d.encode('utf-8')
+
+        r = mock.create_autospec(urllib3.response.HTTPResponse)()
+        r.status = s
+        r.data = data
+        r.getheader.return_value = cluster_id or "abcd1234"
+        return r
+
+    def _mock_api(self, status, d, cluster_id=None):
+        resp = self._prepare_response(status, d, cluster_id=cluster_id)
+        self.client.api_execute = mock.create_autospec(
+            self.client.api_execute, return_value=resp)
+
+    def _mock_exception(self, exc, msg):
+        self.client.api_execute = mock.Mock(side_effect=exc(msg))

--- a/src/etcd/tests/unit/test_lock.py
+++ b/src/etcd/tests/unit/test_lock.py
@@ -1,0 +1,172 @@
+import etcd
+import mock
+from etcd.tests.unit import TestClientApiBase
+
+
+class TestClientLock(TestClientApiBase):
+
+    def recursive_read(self):
+        nodes = [
+            {"key": "/_locks/test_lock/1", "value": "2qwwwq",
+             "modifiedIndex":33,"createdIndex":33},
+            {"key": "/_locks/test_lock/34", "value": self.locker.uuid,
+             "modifiedIndex":34,"createdIndex":34},
+        ]
+        d = {
+            "action": "get",
+            "node": {"dir": True,
+                     "nodes": [{"key":"/_locks/test_lock", "dir": True,
+                                "nodes": nodes}]}
+        }
+        self._mock_api(200, d)
+
+    def setUp(self):
+        super(TestClientLock, self).setUp()
+        self.locker = etcd.Lock(self.client, 'test_lock')
+
+    def test_initialization(self):
+        """
+        Verify the lock gets initialized correctly
+        """
+        self.assertEquals(self.locker.name, u'test_lock')
+        self.assertEquals(self.locker.path, u'/_locks/test_lock')
+        self.assertEquals(self.locker.is_taken, False)
+
+    def test_acquire(self):
+        """
+        Acquiring a precedingly inexistent lock works.
+        """
+        l = etcd.Lock(self.client, 'test_lock')
+        l._find_lock = mock.create_autospec(l._find_lock, return_value=False)
+        l._acquired = mock.create_autospec(l._acquired, return_value=True)
+        # Mock the write
+        d = {
+            u'action': u'set',
+            u'node': {
+                u'modifiedIndex': 190,
+                u'key': u'/_locks/test_lock/1',
+                u'value': l.uuid
+            }
+        }
+        self._mock_api(200, d)
+        self.assertEquals(l.acquire(), True)
+        self.assertEquals(l._sequence, 1)
+
+    def test_is_acquired(self):
+        """
+        Test is_acquired
+        """
+        self.locker._sequence = 1
+        d = {
+            u'action': u'get',
+            u'node': {
+                u'modifiedIndex': 190,
+                u'key': u'/_locks/test_lock/1',
+                u'value': self.locker.uuid
+            }
+        }
+        self._mock_api(200, d)
+        self.locker.is_taken = True
+        self.assertEquals(self.locker.is_acquired, True)
+
+    def test_is_not_acquired(self):
+        """
+        Test is_acquired failures
+        """
+        self.locker._sequence = 2
+        self.locker.is_taken = False
+        self.assertEquals(self.locker.is_acquired, False)
+        self.locker.is_taken = True
+        self._mock_exception(etcd.EtcdKeyNotFound, self.locker.lock_key)
+        self.assertEquals(self.locker.is_acquired, False)
+        self.assertEquals(self.locker.is_taken, False)
+
+    def test_acquired(self):
+        """
+        Test the acquiring primitives
+        """
+        self.locker._sequence = 4
+        retval = ('/_locks/test_lock/4', None)
+        self.locker._get_locker = mock.create_autospec(
+            self.locker._get_locker, return_value=retval)
+        self.assertTrue(self.locker._acquired())
+        self.assertTrue(self.locker.is_taken)
+        retval = ('/_locks/test_lock/1', '/_locks/test_lock/4')
+        self.locker._get_locker = mock.create_autospec(
+            self.locker._get_locker, return_value=retval)
+        self.assertFalse(self.locker._acquired(blocking=False))
+        self.assertFalse(self.locker.is_taken)
+        d = {
+            u'action': u'delete',
+            u'node': {
+                u'modifiedIndex': 190,
+                u'key': u'/_locks/test_lock/1',
+                u'value': self.locker.uuid
+            }
+        }
+        self._mock_api(200, d)
+        returns = [('/_locks/test_lock/1', '/_locks/test_lock/4'),  ('/_locks/test_lock/4', None)]
+
+        def side_effect():
+            return returns.pop()
+
+        self.locker._get_locker = mock.create_autospec(
+            self.locker._get_locker, side_effect=side_effect)
+        self.assertTrue(self.locker._acquired())
+
+    def test_lock_key(self):
+        """
+        Test responses from the lock_key property
+        """
+        with self.assertRaises(ValueError):
+            self.locker.lock_key
+        self.locker._sequence = 5
+        self.assertEquals(u'/_locks/test_lock/5',self.locker.lock_key)
+
+    def test_set_sequence(self):
+        self.locker._set_sequence('/_locks/test_lock/10')
+        self.assertEquals(10, self.locker._sequence)
+
+    def test_find_lock(self):
+        d = {
+            u'action': u'get',
+            u'node': {
+                u'modifiedIndex': 190,
+                u'key': u'/_locks/test_lock/1',
+                u'value': self.locker.uuid
+            }
+        }
+        self._mock_api(200, d)
+        self.locker._sequence = 1
+        self.assertTrue(self.locker._find_lock())
+        # Now let's pretend the lock is not there
+        self._mock_exception(etcd.EtcdKeyNotFound, self.locker.lock_key)
+        self.assertFalse(self.locker._find_lock())
+        self.locker._sequence = None
+        self.recursive_read()
+        self.assertTrue(self.locker._find_lock())
+        self.assertEquals(self.locker._sequence, 34)
+
+
+    def test_get_locker(self):
+        self.recursive_read()
+        self.assertEquals((u'/_locks/test_lock/1', u'/_locks/test_lock/1'),
+                          self.locker._get_locker())
+        with self.assertRaises(etcd.EtcdLockExpired):
+            self.locker._sequence = 35
+            self.locker._get_locker()
+
+    def test_release(self):
+        d = {
+            u'action': u'delete',
+            u'node': {
+                u'modifiedIndex': 190,
+                u'key': u'/_locks/test_lock/1',
+                u'value': self.locker.uuid
+            }
+        }
+        self._mock_api(200, d)
+        self.locker._sequence = 1
+        self.locker.is_taken = True
+        self.locker.release()
+        self.assertFalse(self.locker.is_taken)

--- a/src/etcd/tests/unit/test_request.py
+++ b/src/etcd/tests/unit/test_request.py
@@ -1,40 +1,10 @@
 import etcd
-import unittest
-import json
-import urllib3
+from etcd.tests.unit import TestClientApiBase
 
 try:
     import mock
 except ImportError:
     from unittest import mock
-
-from etcd import EtcdException
-
-
-class TestClientApiBase(unittest.TestCase):
-
-    def setUp(self):
-        self.client = etcd.Client()
-
-    def _prepare_response(self, s, d, cluster_id=None):
-        if isinstance(d, dict):
-            data = json.dumps(d).encode('utf-8')
-        else:
-            data = d.encode('utf-8')
-
-        r = mock.create_autospec(urllib3.response.HTTPResponse)()
-        r.status = s
-        r.data = data
-        r.getheader.return_value = cluster_id or "abcd1234"
-        return r
-
-    def _mock_api(self, status, d, cluster_id=None):
-        resp = self._prepare_response(status, d, cluster_id=cluster_id)
-        self.client.api_execute = mock.create_autospec(
-            self.client.api_execute, return_value=resp)
-
-    def _mock_exception(self, exc, msg):
-        self.client.api_execute = mock.Mock(side_effect=exc(msg))
 
 
 class TestClientApiInternals(TestClientApiBase):


### PR DESCRIPTION
Since server-side locking has been removed from etcd itself, we
implement locks client-side using Zookeeper's recipes as a base.

What we still miss is:

- Integration tests
- Documentation (although the API for the lock is pretty much the same
  we had in the past)