### PR TITLE
Python3 fix when blocking on contented lock

### DIFF
--- a/src/etcd/lock.py
+++ b/src/etcd/lock.py
@@ -99,7 +99,7 @@ class Lock(object):
     def __exit__(self, type, value, traceback):
         self.release()
 
-    def _acquired(self, blocking=True, timeout=None):
+    def _acquired(self, blocking=True, timeout=0):
         locker, nearest = self._get_locker()
         self.is_taken = False
         if self.lock_key == locker:

--- a/src/etcd/tests/unit/test_lock.py
+++ b/src/etcd/tests/unit/test_lock.py
@@ -114,6 +114,27 @@ class TestClientLock(TestClientApiBase):
             self.locker._get_locker, side_effect=side_effect)
         self.assertTrue(self.locker._acquired())
 
+    def test_acquired_no_timeout(self):
+        self.locker._sequence = 4
+        returns = [('/_locks/test_lock/4', None), ('/_locks/test_lock/1', '/_locks/test_lock/4')]
+
+        def side_effect():
+            return returns.pop()
+
+        d = {
+            u'action': u'get',
+            u'node': {
+                u'modifiedIndex': 190,
+                u'key': u'/_locks/test_lock/4',
+                u'value': self.locker.uuid
+            }
+        }
+        self._mock_api(200, d)
+
+        self.locker._get_locker = mock.create_autospec(
+            self.locker._get_locker, side_effect=side_effect)
+        self.assertTrue(self.locker._acquired())
+
     def test_lock_key(self):
         """
         Test responses from the lock_key property
@@ -146,7 +167,6 @@ class TestClientLock(TestClientApiBase):
         self.recursive_read()
         self.assertTrue(self.locker._find_lock())
         self.assertEquals(self.locker._sequence, 34)
-
 
     def test_get_locker(self):
         self.recursive_read()


### PR DESCRIPTION
The default of "None" triggers:
TypeError: unorderable types: NoneType() > int()

Introducing failing test case + fix; mocked API response may be wonky
but it demonstrates issue.

Non-API-breaking slice from https://github.com/jplana/python-etcd/pull/121