### PR TITLE
Introduce EtcdWatchTimedOut exception.

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -4,7 +4,7 @@ parts = python
       test
 develop = .
 eggs = 
-     urllib3==1.7
+     urllib3==1.7.1
      pyOpenSSL==0.13.1
 
 [python]

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ NEWS = open(os.path.join(here, 'NEWS.txt')).read()
 version = '0.4.2'
 
 install_requires = [
-    'urllib3>=1.7'
+    'urllib3>=1.7.1'
 ]
 
 test_requires = [

--- a/src/etcd/__init__.py
+++ b/src/etcd/__init__.py
@@ -200,6 +200,13 @@ class EtcdConnectionFailed(EtcdException):
         self.cause = cause
 
 
+class EtcdWatchTimedOut(EtcdConnectionFailed):
+    """
+    A watch timed out without returning a result.
+    """
+    pass
+
+
 class EtcdWatcherCleared(EtcdException):
     """
     Watcher is cleared due to etcd recovery.

--- a/src/etcd/client.py
+++ b/src/etcd/client.py
@@ -772,6 +772,14 @@ class Client(object):
             except (urllib3.exceptions.HTTPError,
                     HTTPException,
                     socket.error) as e:
+                if (params.get("wait") == "true" and
+                        isinstance(e, urllib3.exceptions.ReadTimeoutError)):
+                    _log.debug("Watch timed out.")
+                    raise etcd.EtcdWatchTimedOut(
+                        "Watch timed out: %r" % e,
+                        cause=e
+                    )
+
                 _log.error("Request to server %s failed: %r",
                            self._base_uri, e)
                 if self._allow_reconnect:

--- a/src/etcd/tests/unit/test_request.py
+++ b/src/etcd/tests/unit/test_request.py
@@ -1,3 +1,5 @@
+import urllib3
+
 import etcd
 from etcd.tests.unit import TestClientApiBase
 
@@ -426,6 +428,20 @@ class TestClientRequest(TestClientApiInterface):
             '/testKey',
             'test',
             prevValue='oldbog'
+        )
+
+    def test_watch_timeout(self):
+        """ Exception will be raised if prevValue != value in test_set """
+        self.client.http.request = mock.create_autospec(
+            self.client.http.request,
+            side_effect=urllib3.exceptions.ReadTimeoutError(self.client.http,
+                                                            "foo",
+                                                            "Read timed out")
+        )
+        self.assertRaises(
+            etcd.EtcdWatchTimedOut,
+            self.client.watch,
+            '/testKey',
         )
 
     def test_path_without_trailing_slash(self):


### PR DESCRIPTION
Suppress spammy error log when a watch times out and raise a dedicated exception instead.

`EtcdWatchTimedOut` subclasses `EtcdConnectionFailed` for back-compatibility.

Revs urllib3 dependency to 1.7.1, which split `TimeoutError` into `ReadTimeoutError` and `ConnectionTimeoutError`.  We don't want to suppress `ConnectionTimeoutError` because that's likely to be a genuine failure.

If the 1.7.1 requirement is a problem then we could do a conditional import but that's a bit messy.

Fixes #132.