### PR TITLE
Fix leader lookup

### DIFF
--- a/src/etcd/client.py
+++ b/src/etcd/client.py
@@ -315,9 +315,9 @@ class Client(object):
         try:
 
             leader = json.loads(
-                self.api_execute(self.version_prefix + '/stats/leader',
+                self.api_execute(self.version_prefix + '/stats/self',
                                  self._MGET).data.decode('utf-8'))
-            return self.members[leader['leader']]
+            return self.members[leader['leaderInfo']['leader']]
         except Exception as e:
             raise etcd.EtcdException("Cannot get leader data: %s" % e)
 

--- a/src/etcd/tests/unit/test_request.py
+++ b/src/etcd/tests/unit/test_request.py
@@ -159,7 +159,7 @@ class TestClientApiInterface(TestClientApiBase):
         """ Can request the leader """
         members = {"ce2a822cea30bfca": {"id": "ce2a822cea30bfca", "name": "default"}}
         mocker.return_value = members
-        self._mock_api(200, {"leader": "ce2a822cea30bfca", "followers": {}})
+        self._mock_api(200, {"leaderInfo":{"leader": "ce2a822cea30bfca", "followers": {}}})
         self.assertEquals(self.client.leader, members["ce2a822cea30bfca"])
 
     def test_set_plain(self):


### PR DESCRIPTION
/stats/leader only works when talking to the leader,
which is not helpful when checking which node it _is_.