### PR TITLE
Cluster ID change shouldn't log a traceback.

### DIFF
--- a/src/etcd/client.py
+++ b/src/etcd/client.py
@@ -851,6 +851,9 @@ class Client(object):
                         "Connection to etcd failed due to %r" % e,
                         cause=e
                     )
+            except etcd.EtcdClusterIdChanged as e:
+                _log.warning(e.message)
+                raise
             except:
                 _log.exception("Unexpected request failure, re-raising.")
                 raise


### PR DESCRIPTION
Having the Cluster ID shouldn't log a traceback, because:

1.  It's not a coding error.
2.  Having a trace isn't really helpful in this case.