### PR TITLE
Make response False on exception

### DIFF
--- a/src/etcd/client.py
+++ b/src/etcd/client.py
@@ -821,6 +821,11 @@ class Client(object):
                         # machines left to try, breaking out of the loop.
                         self._base_uri = self._next_server(cause=e)
                         some_request_failed = True
+
+                        # if exception is raised on _ = response.data
+                        # the condition for while loop will be False
+                        # but we should retry
+                        response = False
                     else:
                         _log.debug("Reconnection disabled, giving up.")
                         raise etcd.EtcdConnectionFailed(


### PR DESCRIPTION
When exception will be raised on _ = response.data we will handle exception, but as response is not None the while loop won't be repeated.

This may lead to an error on _handle_server_response as we may get a response with status == 200 and empty data.

To reproduce bug you need to start watch on some key and kill a server. As HEAD respond with 200 you will have response.status == 200 and JSON parse error will be raised on _handle_server_response.