### PR TITLE
Fix build error on Python 2.6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ NEWS = open(os.path.join(here, 'NEWS.txt')).read()
 version = '0.4.3'
 
 # Dnspython is two different packages depending on python version
-if sys.version_info.major == 2:
+if sys.version_info[0] == 2:
     dns = 'dnspython'
 else:
     dns = 'dnspython3'


### PR DESCRIPTION
In Python 2.6, sys.version_info does not return a named tuple, resulting in a stacktrace similar to the following:

```
                   Complete output from command python setup.py egg_info:
                   Traceback (most recent call last):
                     File "<string>", line 20, in <module>
                     File "/tmp/pip-build-cIKa1X/python-etcd/setup.py", line 12, in <module>
                       if sys.version_info.major == 2:
                   AttributeError: 'tuple' object has no attribute 'major'
```
Tested on Python 2.6, 2.7 and 3.x