### PR TITLE
reset some_request_failed to False on each iteration of the loop

### DIFF
--- a/src/etcd/client.py
+++ b/src/etcd/client.py
@@ -776,7 +776,6 @@ class Client(object):
     def _wrap_request(payload):
         @wraps(payload)
         def wrapper(self, path, method, params=None, timeout=None):
-            some_request_failed = False
             response = False
 
             if timeout is None:
@@ -789,6 +788,7 @@ class Client(object):
                 raise ValueError('Path does not start with /')
 
             while not response:
+                some_request_failed = False
                 try:
                     response = payload(self, path, method,
                                        params=params, timeout=timeout)


### PR DESCRIPTION
otherwise we could get into the situation when the first request has
failed, then _machines_cache has been updated and request executed
successfully and it will try to update _machines_cache once again.

this pull request addresses https://github.com/jplana/python-etcd/issues/152
