### PR TITLE
remove _base_uri only after refresh from cluster

### DIFF
--- a/src/etcd/client.py
+++ b/src/etcd/client.py
@@ -844,7 +844,7 @@ class Client(object):
                     if not self._use_proxies:
                         # The cluster may have changed since last invocation
                         self._machines_cache = self.machines
-                    self._machines_cache.remove(self._base_uri)
+                        self._machines_cache.remove(self._base_uri)
             return self._handle_server_response(response)
         return wrapper
 


### PR DESCRIPTION
hi @lavagetto ,
was overlooked while adding use_proxies support. we have no _base_uri in the _machines_cache already at this point when using proxies.

```
Traceback (most recent call last):
  File "/home/il/src/etcdtest.py", line 9, in <module>
    print econfig.read("/version").value
  File "/home/il/src/deployr/pleiades/.direnv/python-2.7.3/local/lib/python2.7/site-packages/etcd/client.py", line 536, in read
    timeout=timeout)
  File "/home/il/src/deployr/pleiades/.direnv/python-2.7.3/local/lib/python2.7/site-packages/etcd/client.py", line 847, in wrapper
    self._machines_cache.remove(self._base_uri)
ValueError: list.remove(x): x not in list
```
