### PR TITLE
Yield self only if requested when there are no children

### DIFF
--- a/src/etcd/__init__.py
+++ b/src/etcd/__init__.py
@@ -74,7 +74,8 @@ class EtcdResult(object):
         """
         if not self._children:
             #if the current result is a leaf, return itself
-            yield self
+            if not leaves_only:
+                yield self
             return
         else:
             # node is not a leaf


### PR DESCRIPTION
When there are no children, self is yielded even though the ```leaves_only``` parameter is True when you use ```my_result.children```.