### PR TITLE
Set default value of `value` of `Client.write`

### DIFF
--- a/src/etcd/client.py
+++ b/src/etcd/client.py
@@ -398,7 +398,7 @@ class Client(object):
         return key
 
 
-    def write(self, key, value, ttl=None, dir=False, append=False, **kwdargs):
+    def write(self, key, value=None, ttl=None, dir=False, append=False, **kwdargs):
         """
         Writes the value for a key, possibly doing atomit Compare-and-Swap
 


### PR DESCRIPTION
In the documentation, `value` argument looks should be omitted.

``` python
client.write('/nodes/queue', dir=True)
```
