### PR TITLE
Stringify username and password

### DIFF
--- a/src/etcd/client.py
+++ b/src/etcd/client.py
@@ -929,6 +929,6 @@ class Client(object):
 
     def _get_headers(self):
         if self.username and self.password:
-            credentials = ':'.join((self.username, self.password))
+            credentials = ':'.join((str(self.username), str(self.password)))
             return urllib3.make_headers(basic_auth=credentials)
         return {}


### PR DESCRIPTION
While testing, I passed in a test password of `123`. This caused the following error:

```
  File "/usr/lib/python2.7/site-packages/etcd/client.py", line 932, in _get_headers
    credentials = ':'.join((self.username, self.password))
TypeError: sequence item 1: expected string, int found
```

I've set my own project to stringify the username and password, but I thought it might be helpful upstream.
