### PR TITLE
Fix doc comment of client.watch()

### DIFF
--- a/src/etcd/client.py
+++ b/src/etcd/client.py
@@ -695,7 +695,7 @@ class Client(object):
         Raises:
             KeyValue:  If the key doesn't exists.
 
-            urllib3.exceptions.TimeoutError: If timeout is reached.
+            etcd.EtcdWatchTimedOut: If timeout is reached.
 
         >>> print client.watch('/key').value
         'value'

--- a/src/etcd/client.py
+++ b/src/etcd/client.py
@@ -693,7 +693,7 @@ class Client(object):
             client.EtcdResult
 
         Raises:
-            KeyValue:  If the key doesn't exists.
+            KeyValue:  If the key doesn't exist.
 
             etcd.EtcdWatchTimedOut: If timeout is reached.
 


### PR DESCRIPTION
The exception raised when the timeout expires is etcd.EtcdWatchTimedOut
