### PR TITLE
Python3 fix when blocking on contented lock, episode 2

### DIFF
--- a/src/etcd/lock.py
+++ b/src/etcd/lock.py
@@ -54,7 +54,7 @@ class Lock(object):
             self.is_taken = False
             return False
 
-    def acquire(self, blocking=True, lock_ttl=3600, timeout=None):
+    def acquire(self, blocking=True, lock_ttl=3600, timeout=0):
         """
         Acquire the lock.
 


### PR DESCRIPTION
Same issue as [PR#126](https://github.com/jplana/python-etcd/pull/126)
timout = None can cascade into the call to self._aquired triggering:
TypeError: unorderable types: NoneType() > int()