### PR TITLE
optional disable ssl hostname verification to enable self signed certificates

### DIFF
--- a/src/etcd/client.py
+++ b/src/etcd/client.py
@@ -58,6 +58,7 @@ class Client(object):
             protocol='http',
             cert=None,
             ca_cert=None,
+            assert_hostname=False,
             username=None,
             password=None,
             allow_reconnect=False,
@@ -90,6 +91,8 @@ class Client(object):
 
             ca_cert (str): The ca certificate. If pressent it will enable
                            validation.
+
+            assert_hostname (bool): default False, disable the ssl hostname verification.
 
             username (str): username for etcd authentication.
 
@@ -171,6 +174,7 @@ class Client(object):
         if ca_cert:
             kw['ca_certs'] = ca_cert
             kw['cert_reqs'] = ssl.CERT_REQUIRED
+            kw['assert_hostname'] = assert_hostname
 
         self.username = None
         self.password = None


### PR DESCRIPTION
optional disable ssl hostname verification to enable self signed certificates。if the self-signed ca.pem don't have a common name or subjectAltName, it will fail as follows:

````
Traceback (most recent call last):
  File "etcd_info.py", line 32, in <module>
    print client.read("/cd1f9462240b44bbf948bc5b0ea843327/registry/services/").value
  File "/usr/local/lib/python2.7/dist-packages/python_etcd-0.4.3-py2.7.egg/etcd/client.py", line 536, in read
    timeout=timeout)
  File "/usr/local/lib/python2.7/dist-packages/python_etcd-0.4.3-py2.7.egg/etcd/client.py", line 834, in wrapper
    cause=e
EtcdConnectionFailed: Connection to etcd failed due to SSLError(CertificateError('no appropriate commonName or subjectAltName fields were found',),)
````