### PR TITLE
Moved to positional args in string formatting

### DIFF
--- a/src/etcd/__init__.py
+++ b/src/etcd/__init__.py
@@ -291,7 +291,7 @@ class EtcdError(object):
         error_code = payload.get("errorCode")
         message = payload.get("message")
         cause = payload.get("cause")
-        msg = '{} : {}'.format(message, cause)
+        msg = '{0} : {1}'.format(message, cause)
         status = payload.get("status")
         # Some general status handling, as
         # not all endpoints return coherent error messages

--- a/src/etcd/auth.py
+++ b/src/etcd/auth.py
@@ -12,13 +12,13 @@ class EtcdAuthBase(object):
     def __init__(self, client, name):
         self.client = client
         self.name = name
-        self.uri = "{}/auth/{}s/{}".format(self.client.version_prefix,
-                                           self.entity, self.name)
+        self.uri = "{0}/auth/{1}s/{2}".format(self.client.version_prefix,
+                                              self.entity, self.name)
 
     @property
     def names(self):
-        key = "{}s".format(self.entity)
-        uri = "{}/auth/{}".format(self.client.version_prefix, key)
+        key = "{0}s".format(self.entity)
+        uri = "{0}/auth/{1}".format(self.client.version_prefix, key)
         response = self.client.api_execute(uri, self.client._MGET)
         return json.loads(response.data.decode('utf-8'))[key]
 
@@ -36,7 +36,7 @@ class EtcdAuthBase(object):
                        self.entity, self.client._base_uri,
                        self.client.version_prefix, e)
             raise etcd.EtcdException(
-                "Could not fetch {} '{}'".format(self.entity, self.name))
+                "Could not fetch {0} '{1}'".format(self.entity, self.name))
 
         self._from_net(response.data)
 
@@ -60,8 +60,8 @@ class EtcdAuthBase(object):
             _log.error("Failed to write %s '%s'", self.entity, self.name)
             # TODO: fine-grained exception handling
             raise etcd.EtcdException(
-                "Could not write {} '{}': {}".format(self.entity,
-                                                     self.name, e))
+                "Could not write {0} '{1}': {2}".format(self.entity,
+                                                        self.name, e))
 
     def delete(self):
         try:
@@ -76,7 +76,7 @@ class EtcdAuthBase(object):
             _log.error("Failed to delete %s in %s%s: %r",
                        self.entity, self._base_uri, self.version_prefix, e)
             raise etcd.EtcdException(
-                "Could not delete {} '{}'".format(self.entity, self.name))
+                "Could not delete {0} '{1}'".format(self.entity, self.name))
 
     def _from_net(self, data):
         raise NotImplementedError()
@@ -241,7 +241,7 @@ class EtcdRole(EtcdAuthBase):
 class Auth(object):
     def __init__(self, client):
         self.client = client
-        self.uri = "{}/auth/enable".format(self.client.version_prefix)
+        self.uri = "{0}/auth/enable".format(self.client.version_prefix)
 
     @property
     def active(self):

--- a/src/etcd/client.py
+++ b/src/etcd/client.py
@@ -208,7 +208,7 @@ class Client(object):
                        self._machines_cache)
 
     def _discover(self, domain):
-        srv_name = "_etcd._tcp.{}".format(domain)
+        srv_name = "_etcd._tcp.{0}".format(domain)
         answers = dns.resolver.query(srv_name, 'SRV')
         hosts = []
         for answer in answers:
@@ -394,7 +394,7 @@ class Client(object):
 
     def _sanitize_key(self, key):
         if not key.startswith('/'):
-            key = "/{}".format(key)
+            key = "/{0}".format(key)
         return key
 
 
@@ -875,7 +875,7 @@ class Client(object):
                 preload_content=False)
         else:
                     raise etcd.EtcdException(
-                        'HTTP method {} not supported'.format(method))
+                        'HTTP method {0} not supported'.format(method))
 
     @_wrap_request
     def api_execute_json(self, path, method, params=None, timeout=None):
@@ -906,8 +906,8 @@ class Client(object):
             # time.
             self.http.clear()
             raise etcd.EtcdClusterIdChanged(
-                'The UUID of the cluster changed from {} to '
-                '{}.'.format(old_expected_cluster_id, cluster_id))
+                'The UUID of the cluster changed from {0} to '
+                '{1}.'.format(old_expected_cluster_id, cluster_id))
 
     def _handle_server_response(self, response):
         """ Handles the server response """

--- a/src/etcd/lock.py
+++ b/src/etcd/lock.py
@@ -17,7 +17,7 @@ class Lock(object):
         # prevent us from getting back the full path name. We prefix our
         # lock name with a uuid and can check for its presence on retry.
         self._uuid = uuid.uuid4().hex
-        self.path = "/_locks/{}".format(lock_name)
+        self.path = "/_locks/{0}".format(lock_name)
         self.is_taken = False
         self._sequence = None
         _log.debug("Initiating lock for %s with uuid %s", self.path, self._uuid)

--- a/src/etcd/tests/integration/helpers.py
+++ b/src/etcd/tests/integration/helpers.py
@@ -33,14 +33,14 @@ class EtcdProcessHelper(object):
 
     def run(self, number=1, proc_args=[]):
         if number > 1:
-            initial_cluster = ",".join([ "test-node-{}={}127.0.0.1:{}".format(slot, 'http://', self.internal_port_range_start + slot) for slot in range(0, number)])
+            initial_cluster = ",".join([ "test-node-{0}={1}127.0.0.1:{2}".format(slot, 'http://', self.internal_port_range_start + slot) for slot in range(0, number)])
             proc_args.extend([
                 '-initial-cluster', initial_cluster,
                 '-initial-cluster-state', 'new'
             ])
         else:
             proc_args.extend([
-                '-initial-cluster', 'test-node-0=http://127.0.0.1:{}'.format(self.internal_port_range_start),
+                '-initial-cluster', 'test-node-0=http://127.0.0.1:{0}'.format(self.internal_port_range_start),
                 '-initial-cluster-state', 'new'
             ])
 

--- a/src/etcd/tests/unit/test_client.py
+++ b/src/etcd/tests/unit/test_client.py
@@ -148,7 +148,7 @@ class TestClient(unittest.TestCase):
                 method = dns.name.from_unicode
             except AttributeError:
                 method = dns.name.from_text
-            r.target = method(u'etcd{}.example.com'.format(i))
+            r.target = method(u'etcd{0}.example.com'.format(i))
             answers.append(r)
         dns.resolver.query = mock.create_autospec(dns.resolver.query, return_value=answers)
         self.machines = etcd.Client.machines


### PR DESCRIPTION
In Python 3.1 the need for positional arguments in string formatting
became optional. However, there are a lot of people using Python 3.0.x
and 2.6.x who could benefit from using the python-etcd library. This
change would allow older versions of Python to be able to use the
library without requiring them to be officially supported.