### PR TITLE
 Fix UnicodeEncodeError when message/cause is unicode

### DIFF
--- a/src/etcd/__init__.py
+++ b/src/etcd/__init__.py
@@ -291,7 +291,7 @@ class EtcdError(object):
         error_code = payload.get("errorCode")
         message = payload.get("message")
         cause = payload.get("cause")
-        msg = '{} : {}'.format(message, cause)
+        msg = u'{} : {}'.format(message, cause)
         status = payload.get("status")
         # Some general status handling, as
         # not all endpoints return coherent error messages

--- a/src/etcd/client.py
+++ b/src/etcd/client.py
@@ -877,7 +877,8 @@ class Client(object):
                     if not self._use_proxies:
                         # The cluster may have changed since last invocation
                         self._machines_cache = self.machines
-                    self._machines_cache.remove(self._base_uri)
+                    if self._base_uri in self._machines_cache:
+                        self._machines_cache.remove(self._base_uri)
             return self._handle_server_response(response)
         return wrapper
 

--- a/src/etcd/client.py
+++ b/src/etcd/client.py
@@ -67,7 +67,8 @@ class Client(object):
             allow_reconnect=False,
             use_proxies=False,
             expected_cluster_id=None,
-            per_host_pool_size=10
+            per_host_pool_size=10,
+            pool_kw=None
     ):
         """
         Initialize the client.
@@ -153,6 +154,9 @@ class Client(object):
         kw = {
           'maxsize': per_host_pool_size
         }
+
+        if pool_kw is not None:
+            kw.update(pool_kw)
 
         if self._read_timeout > 0:
             kw['timeout'] = self._read_timeout

--- a/src/etcd/client.py
+++ b/src/etcd/client.py
@@ -27,6 +27,10 @@ try:
 except ImportError:
     from urllib.parse import urlparse
 
+try:
+    from urllib.parse import quote
+except ImportError:
+    from urllib import quote
 
 _log = logging.getLogger(__name__)
 
@@ -393,6 +397,8 @@ class Client(object):
             return False
 
     def _sanitize_key(self, key):
+        if not all(ord(c) < 128 for c in key):
+            key = quote(key)
         if not key.startswith('/'):
             key = "/{}".format(key)
         return key

--- a/src/etcd/tests/integration/test_simple.py
+++ b/src/etcd/tests/integration/test_simple.py
@@ -1,3 +1,4 @@
+#encoding=utf-8
 import os
 import time
 import shutil
@@ -135,6 +136,8 @@ class TestSimple(EtcdIntegrationTest):
         self.assertEquals(new_res.ttl, 120)
 
 
+    def test_nonascii_read(self):
+        self.assertRaises(etcd.EtcdKeyNotFound, self.client.read, '中文')
 
 class TestErrors(EtcdIntegrationTest):
 

--- a/src/etcd/tests/unit/test_client.py
+++ b/src/etcd/tests/unit/test_client.py
@@ -159,3 +159,7 @@ class TestClient(unittest.TestCase):
         self.assertEquals(c.port, 2379)
         self.assertEquals(c._machines_cache,
                           [u'https://etcd2.example.com:2379'])
+
+    def test_set_retries(self):
+        client = etcd.Client(pool_kw=dict(retries=0))
+        assert client.http.connection_pool_kw.get('retries') == 0


### PR DESCRIPTION
When message/cause comes from json.loads, it will be unicode. If message/cause is unicode and contains non-ascii character like chinese, it will cause UnicodeEncodeError like this:

```
  File "/home/env/django-1.3/lib/python2.7/site-packages/etcd/client.py", line 536, in read
    timeout=timeout)
  File "/home/env/django-1.3/lib/python2.7/site-packages/etcd/client.py", line 848, in wrapper
    return self._handle_server_response(response)
  File "/home/env/django-1.3/lib/python2.7/site-packages/etcd/client.py", line 928, in _handle_server_response
    etcd.EtcdError.handle(r)
  File "/home/env/django-1.3/lib/python2.7/site-packages/etcd/__init__.py", line 294, in handle
    msg = '{} : {}'.format(message, cause)
UnicodeEncodeError: 'ascii' codec can't encode characters in position 25-26: ordinal not in range(128)
```
