### PR TITLE
Fix ValueError: zero length field name in format on Python 2.6

### DIFF
--- a/src/etcd/__init__.py
+++ b/src/etcd/__init__.py
@@ -291,7 +291,7 @@ class EtcdError(object):
         error_code = payload.get("errorCode")
         message = payload.get("message")
         cause = payload.get("cause")
-        msg = '{} : {}'.format(message, cause)
+        msg = '{0} : {1}'.format(message, cause)
         status = payload.get("status")
         # Some general status handling, as
         # not all endpoints return coherent error messages


### PR DESCRIPTION
This small fix make python-etcd master branch compatible with Python 2.6.
