### PR TITLE
Fix incompatibility with etcd 3: don't set TLSv1 protocol in the client

### DIFF
--- a/src/etcd/client.py
+++ b/src/etcd/client.py
@@ -157,12 +157,6 @@ class Client(object):
         if self._read_timeout > 0:
             kw['timeout'] = self._read_timeout
 
-        if protocol == 'https':
-            # If we don't allow TLSv1, clients using older version of OpenSSL
-            # (<1.0) won't be able to connect.
-            _log.debug("HTTPS enabled.")
-            kw['ssl_version'] = ssl.PROTOCOL_TLSv1
-
         if cert:
             if isinstance(cert, tuple):
                 # Key and cert are separate


### PR DESCRIPTION
Calico users have been seeing incompatibility with etcd v3 (https://github.com/projectcalico/calico-containers/issues/1107), because specifying TLSv1 explicitly prevents urllib3 from negotiating a newer version of the protocol. 

This change was recommended by @lukasa, who is one of the maintainers of urllib3: https://github.com/projectcalico/python-etcd/issues/16.