### PR TITLE
fix bug introduced from dnspython dep upgrade

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,15 +8,9 @@ NEWS = open(os.path.join(here, 'NEWS.txt')).read()
 
 version = '0.4.3'
 
-# Dnspython is two different packages depending on python version
-if sys.version_info[0] == 2:
-    dns = 'dnspython'
-else:
-    dns = 'dnspython3'
-
 install_requires = [
     'urllib3>=1.7.1',
-    dns
+    'dnspython'
 ]
 
 test_requires = [

--- a/src/etcd/client.py
+++ b/src/etcd/client.py
@@ -210,8 +210,11 @@ class Client(object):
         answers = dns.resolver.query(srv_name, 'SRV')
         hosts = []
         for answer in answers:
+			host = answer.target.to_text(omit_final_dot=True)
+			if not isinstance(host, str):
+				host = host.decode()
             hosts.append(
-            	(answer.target.to_text(omit_final_dot=True).decode(), answer.port))
+            	(host, answer.port))
         _log.debug("Found %s", hosts)
         if not len(hosts):
             raise ValueError("The SRV record is present but no host were found")

--- a/src/etcd/client.py
+++ b/src/etcd/client.py
@@ -210,11 +210,11 @@ class Client(object):
         answers = dns.resolver.query(srv_name, 'SRV')
         hosts = []
         for answer in answers:
-			host = answer.target.to_text(omit_final_dot=True)
-			if not isinstance(host, str):
-				host = host.decode()
+            host = answer.target.to_text(omit_final_dot=True)
+            if not isinstance(host, str):
+                host = host.decode()
             hosts.append(
-            	(host, answer.port))
+                (host, answer.port))
         _log.debug("Found %s", hosts)
         if not len(hosts):
             raise ValueError("The SRV record is present but no host were found")

--- a/src/etcd/client.py
+++ b/src/etcd/client.py
@@ -211,7 +211,7 @@ class Client(object):
         hosts = []
         for answer in answers:
             hosts.append(
-                (answer.target.to_text(omit_final_dot=True), answer.port))
+            	(answer.target.to_text(omit_final_dot=True).decode(), answer.port))
         _log.debug("Found %s", hosts)
         if not len(hosts):
             raise ValueError("The SRV record is present but no host were found")


### PR DESCRIPTION
between version 1.12.0 and 1.14.0 of dnspython the return value of answer.target.to_text(omit_final_dot=True) has switched from a python string to a byte string, causing this exception to be thrown .

`etcd.EtcdException: Could not get the list of servers, maybe you provided the wrong host(s) to connect to?
`

further up the stack trace is this `urllib3.exceptions.MaxRetryError: HTTPConnectionPool(host="b'example.com'", port=2379): Max retries exceeded with url: /v2/machines (Caused by NewConnectionError('<urllib3.connection.HTTPConnection object at 0x7f1eb30af5f8>: Failed to establish a new connection: [Errno -2] Name or service not known',))`
notice the host argument.

calling .decode() on the string returned from dns.resolver.query() fixes this issue.