### PR TITLE
Ground work for updating auth

### DIFF
--- a/src/etcd/tests/test_auth.py
+++ b/src/etcd/tests/test_auth.py
@@ -127,7 +127,13 @@ class EtcdRoleTest(TestEtcdAuthBase):
         except:
             self.fail('Reading an existing role failed')
 
-        self.assertEquals(r.acls, {'*': 'RW'})
+        # XXX The ACL path result changed from '*' to '/*' at some point
+        #     between etcd-2.2.2 and 2.2.5.  They're equivalent so allow
+        #     for both.
+        if '/*' in r.acls:
+            self.assertEquals(r.acls, {'/*': 'RW'})
+        else:
+            self.assertEquals(r.acls, {'*': 'RW'})
         # We can actually skip most other read tests as they are common
         # with EtcdUser
 

--- a/src/etcd/tests/unit/test_client.py
+++ b/src/etcd/tests/unit/test_client.py
@@ -121,6 +121,58 @@ class TestClient(unittest.TestCase):
             'authorization': 'Basic dXNlcm5hbWU6cGFzc3dvcmQ='
         }
 
+    def test__set_version_info(self):
+        """Verify _set_version_info makes the proper call to the server"""
+        with mock.patch('urllib3.PoolManager') as _pm:
+            _request = _pm().request
+            # Return the expected data type
+            _request.return_value = mock.MagicMock(
+                data=b'{"etcdserver": "2.2.3", "etcdcluster": "2.3.0"}')
+
+            # Create the client and make the call.
+            client = etcd.Client()
+            client._set_version_info()
+
+            # Verify we call the proper endpoint
+            _request.assert_called_once_with(
+                client._MGET,
+                client._base_uri + '/version',
+                headers=mock.ANY,
+                redirect=mock.ANY,
+                timeout=mock.ANY)
+
+            # Verify the properties while we are here
+            self.assertEquals('2.2.3', client.version)
+            self.assertEquals('2.3.0', client.cluster_version)
+
+    def test_version_property(self):
+        """Ensure the version property is set on first access."""
+        with mock.patch('urllib3.PoolManager') as _pm:
+            _request = _pm().request
+            # Return the expected data type
+            _request.return_value = mock.MagicMock(
+                data=b'{"etcdserver": "2.2.3", "etcdcluster": "2.3.0"}')
+
+            # Create the client.
+            client = etcd.Client()
+
+            # Verify the version property is set
+            self.assertEquals('2.2.3', client.version)
+
+    def test_cluster_version_property(self):
+        """Ensure the cluster version property is set on first access."""
+        with mock.patch('urllib3.PoolManager') as _pm:
+            _request = _pm().request
+            # Return the expected data type
+            _request.return_value = mock.MagicMock(
+                data=b'{"etcdserver": "2.2.3", "etcdcluster": "2.3.0"}')
+
+            # Create the client.
+            client = etcd.Client()
+
+            # Verify the cluster_version property is set
+            self.assertEquals('2.3.0', client.cluster_version)
+
     def test_get_headers_without_auth(self):
         client = etcd.Client()
         assert client._get_headers() == {}


### PR DESCRIPTION
After upgrading to ``etcd`` 2.3.x we started to notice the authentication code was failing. As it turns out there was a change somewhere between 2.1.x and 2.3.x that changes the resulting auth data.

Examples:
- https://coreos.com/etcd/docs/2.1.3/auth_api.html#users-1
- https://coreos.com/etcd/docs/2.3.7/auth_api.html#users-1

This change starts the upgrade process with the following commits:
- Ported @mbarnes auth test fix for acls
- Added version/cluster_version properties to ``etcd.Client``

Hopefully helpful for https://github.com/jplana/python-etcd/issues/210