### PR TITLE
Change default client port to 2379

### DIFF
--- a/src/etcd/client.py
+++ b/src/etcd/client.py
@@ -50,7 +50,7 @@ class Client(object):
     def __init__(
             self,
             host='127.0.0.1',
-            port=4001,
+            port=2379,
             srv_domain=None,
             version_prefix='/v2',
             read_timeout=60,


### PR DESCRIPTION
Per newer releases of etcd, 2379 is the default port for client traffic.
Refer:
https://github.com/coreos/etcd/blob/release-3.0/etcd.conf.yml.sample#L29

etcd.Client still uses old port 4001 as the default, which means it
cannot be used out of the box.