### PR TITLE
Fix bug when lock in contextmanager way

### DIFF
--- a/src/etcd/lock.py
+++ b/src/etcd/lock.py
@@ -94,7 +94,7 @@ class Lock(object):
         """
         You can use the lock as a contextmanager
         """
-        self.acquire(blocking=True, lock_ttl=0)
+        self.acquire(blocking=True)
 
     def __exit__(self, type, value, traceback):
         self.release()


### PR DESCRIPTION
Lock TTL was set to 0 which cause the lock expiring immediately and acquire will never success and             raise etcd.EtcdLockExpired(u"Lock not found").
```python
    res = self.client.write(self.path, self.uuid, ttl=lock_ttl, append=True)  # write with ttl=0
```
```python
    def _get_locker(self):
        results = [res for res in
                   self.client.read(self.path, recursive=True).leaves] # results will be empty
        if not self._sequence:
            self._find_lock()
        l = sorted([r.key for r in results])
        _log.debug("Lock keys found: %s", l)
        try:
            i = l.index(self.lock_key)
            if i == 0:
                _log.debug("No key before our one, we are the locker")
                return (l[0], None)
            else:
                _log.debug("Locker: %s, key to watch: %s", l[0], l[i-1])
                return (l[0], l[i-1])
        except ValueError:
            # Something very wrong is going on, most probably
            # our lock has expired
            raise etcd.EtcdLockExpired(u"Lock not found")
```




