### PR TITLE
Fix EtcdResult.leaves returns itself

### DIFF
--- a/src/etcd/__init__.py
+++ b/src/etcd/__init__.py
@@ -72,19 +72,13 @@ class EtcdResult(object):
 
 
         """
-        if not self._children:
-            #if the current result is a leaf, return itself
+        if not leaves_only:
             yield self
-            return
-        else:
-            # node is not a leaf
-            if not leaves_only:
-                yield self
-            for n in self._children:
-                node = EtcdResult(None, n)
-                for child in node.get_subtree(leaves_only=leaves_only):
-                    yield child
-        return
+
+        for n in self._children:
+            node = EtcdResult(None, n)
+            for child in node.get_subtree(leaves_only=leaves_only):
+                yield child
 
     @property
     def leaves(self):

--- a/src/etcd/tests/unit/test_result.py
+++ b/src/etcd/tests/unit/test_result.py
@@ -30,7 +30,7 @@ class TestEtcdResult(unittest.TestCase):
 
         # Get subtree returns itself, whether or not leaves_only
         subtree = list(result.get_subtree(leaves_only=True))
-        self.assertListEqual([result], subtree)
+        self.assertListEqual([], subtree)
         subtree = list(result.get_subtree(leaves_only=False))
         self.assertListEqual([result], subtree)
 


### PR DESCRIPTION
EtcdResult.leaves returns single item (itself) if it has
no children. With this patch EtcdResult.leaves as well as
EtcdResult.get_subtree(leaves_only=True) generates empty
sequence if it has no children.
Fixes #155