### PR TITLE
Fix eternal watch cause error 'the requested history has been cleared'

### DIFF
--- a/src/etcd/client.py
+++ b/src/etcd/client.py
@@ -757,7 +757,8 @@ class Client(object):
         local_index = index
         while True:
             response = self.watch(key, index=local_index, timeout=0, recursive=recursive)
-            local_index = response.modifiedIndex + 1
+            if index:
+                local_index = response.modifiedIndex + 1
             yield response
 
     def get_lock(self, *args, **kwargs):


### PR DESCRIPTION
If client occur reconnection and etcd waitIndex less than event history startIndex will be cause error, like “the requested history has been cleared [6445109/1]”
