### PR TITLE
Update etcd, urllib3, pyopenssl versions in travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ python:
   - "3.5"
 
 before_install:
-  - ./build_etcd.sh v2.2.0
+  - ./download_etcd.sh 2.3.7
   - pip install --upgrade setuptools
 
 # command to install dependencies
@@ -16,7 +16,7 @@ install:
 
 # command to run tests
 script:
-  PATH=$PATH:./etcd/bin coverage run --source=src/etcd --omit="src/etcd/tests/*" bin/test
+  PATH=$PATH:./bin coverage run --source=src/etcd --omit="src/etcd/tests/*" bin/test
 
 after_success: coveralls
 # Add env var to detect it during build

--- a/build_etcd.sh
+++ b/build_etcd.sh
@@ -9,10 +9,16 @@ fi
 
 echo "Using ETCD version $ETCD_VERSION"
 
+BASE=$PWD
+mkdir -p gopath/src/coreos/
+export GOPATH=$BASE/gopath/
+cd $GOPATH/src/coreos
 git clone https://github.com/coreos/etcd.git
 cd etcd
-git checkout $ETCD_VERSION
+git checkout -b buildout $ETCD_VERSION
 ./build
+cd $BASE
+cp -r $GOPATH/src/coreos/etcd/bin .
 
 
 ${TRAVIS:?"This is not a Travis build. All Done"}

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -5,8 +5,8 @@ parts = python
       coverage
 develop = .
 eggs = 
-     urllib3==1.7.1
-     pyOpenSSL==0.13.1
+     urllib3==1.19.1
+     pyOpenSSL==16.2
      ${deps:extraeggs}
 
 [python]

--- a/download_etcd.sh
+++ b/download_etcd.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -e
+VERSION=${1:-2.3.7}
+mkdir -p bin
+URL="https://github.com/coreos/etcd/releases/download/v${VERSION}/etcd-v${VERSION}-linux-amd64.tar.gz"
+curl -L $URL | tar -C ./bin --strip-components=1 -xzvf - "etcd-v${VERSION}-linux-amd64/etcd"

--- a/src/etcd/auth.py
+++ b/src/etcd/auth.py
@@ -14,13 +14,28 @@ class EtcdAuthBase(object):
         self.name = name
         self.uri = "{}/auth/{}s/{}".format(self.client.version_prefix,
                                            self.entity, self.name)
+        # This will be lazily evaluated if not manually set
+        self._legacy_api = None
+
+    @property
+    def legacy_api(self):
+        if self._legacy_api is None:
+            # The auth API has changed between 2.2 and 2.3, true story!
+            major, minor, _ = map(int, self.client.version.split('.'))
+            self._legacy_api = (major < 3 and minor < 3)
+        return self._legacy_api
+
 
     @property
     def names(self):
         key = "{}s".format(self.entity)
         uri = "{}/auth/{}".format(self.client.version_prefix, key)
         response = self.client.api_execute(uri, self.client._MGET)
-        return json.loads(response.data.decode('utf-8'))[key]
+        if self.legacy_api:
+            return json.loads(response.data.decode('utf-8'))[key]
+        else:
+            return [obj[self.entity]
+                    for obj in json.loads(response.data.decode('utf-8'))[key]]
 
     def read(self):
         try:
@@ -102,7 +117,16 @@ class EtcdUser(EtcdAuthBase):
 
     def _from_net(self, data):
         d = json.loads(data.decode('utf-8'))
-        self.roles = d.get('roles', [])
+        roles = d.get('roles', [])
+        try:
+            self.roles = roles
+        except TypeError:
+            # with the change of API, PUT responses are different
+            # from GET reponses, which makes everything so funny.
+            # Specifically, PUT responses are the same as before...
+            if self.legacy_api:
+                raise
+            self.roles = [obj['role'] for obj in roles]
         self.name = d.get('user')
 
     def _to_net(self, prevobj=None):

--- a/src/etcd/tests/test_auth.py
+++ b/src/etcd/tests/test_auth.py
@@ -93,6 +93,10 @@ class EtcdUserTest(TestEtcdAuthBase):
         self.assertEquals(u.roles, set(['guest', 'root']))
         # set roles as a list, it works!
         u.roles = ['guest', 'test_group']
+        # We need this or the new API will return an internal error
+        r = auth.EtcdRole(self.client, 'test_group')
+        r.acls = {'*': 'R', '/test/*': 'RW'}
+        r.write()
         try:
             u.write()
         except:


### PR DESCRIPTION
Also, update travis build to use etcd 2.3.7, and recent versions of pyopenssl and urllib3.

Closes #210 