### PR TITLE
Reduce reraised-exception log to debug

### DIFF
--- a/src/etcd/client.py
+++ b/src/etcd/client.py
@@ -896,7 +896,7 @@ class Client(object):
                     _log.warning(e)
                     raise
                 except:
-                    _log.exception("Unexpected request failure, re-raising.")
+                    _log.debug("Unexpected request failure, re-raising.")
                     raise
 
                 if some_request_failed:


### PR DESCRIPTION
When an exception occurs during a request, it can be for harmless
reasons (using an eventlet.timeout, for example).  Also, the exception
is already returned to the caller, who can better judge its severity.
Logging it here as an exception puts a lot of ERROR-level logs out
that might not, in fact, reflect errors,

This lowers the log level to a single-line debug.