### PR TITLE
client.write can't create dir

### DIFF
--- a/src/etcd/client.py
+++ b/src/etcd/client.py
@@ -435,7 +435,7 @@ class Client(object):
             key = "/{}".format(key)
         return key
 
-    def write(self, key, value, ttl=None, dir=False, append=False, **kwdargs):
+    def write(self, key, value=None, ttl=None, dir=False, append=False, **kwdargs):
         """
         Writes the value for a key, possibly doing atomic Compare-and-Swap
 


### PR DESCRIPTION
client.write("/test/ni", dir=True) can't create dir 

because the "write" method required "value" field, and has "value" field will raise Exception:
Traceback (most recent call last):
  File "<console>", line 1, in <module>
TypeError: write() takes at least 3 arguments (3 given)

pls fix it