### PR TITLE
Update DNS discovery to better match ETCD documentation.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ build
 dist
 docs
 .coverage
+.venv
+.env

--- a/src/etcd/client.py
+++ b/src/etcd/client.py
@@ -122,7 +122,7 @@ class Client(object):
         # If a DNS record is provided, use it to get the hosts list
         if srv_domain is not None:
             try:
-                host = self._discover(srv_domain, use_ssl=srv_use_ssl)
+                host = self._discover(srv_domain)
             except Exception as e:
                 _log.error("Could not discover the etcd hosts from %s: %s",
                            srv_domain, e)


### PR DESCRIPTION
Hi,

I've made a little change to better match the documentation available [here](https://coreos.com/etcd/docs/latest/v2/clustering.html#dns-discovery). It will now search for __etcd-client._tcp.domain_ instead of __etcd._tcp.domain_. I did not had time to implement searching for __etcd-client-ssl_ first and if there's an error, search for __etcd-client_ although I've exposed a flag to use it if people want to.

Thanks for the work.

Sebastien