### PR TITLE
AUTH : Fix version check to avoid crashing on API detection through v…

### DIFF
--- a/src/etcd/auth.py
+++ b/src/etcd/auth.py
@@ -21,7 +21,7 @@ class EtcdAuthBase(object):
     def legacy_api(self):
         if self._legacy_api is None:
             # The auth API has changed between 2.2 and 2.3, true story!
-            major, minor, _ = map(int, self.client.version.split('.'))
+            major, minor = map(int, self.client.version[:3].split('.'))
             self._legacy_api = (major < 3 and minor < 3)
         return self._legacy_api
 


### PR DESCRIPTION
Dear Maintainer,

I've ecountered an error using the GIT version of Etcd, you get versions such as "3.2.0-rc.1+git"

Previous code led to this error:

 ```
 "/usr/lib/python2.7/site-packages/etcd/auth.py", line 25, in legacy_api
major, minor, _ = map(int, self.client.version.split('.'))
ValueError: invalid literal for int() with base 10: '0-rc'
```
This proposes a (very) simple fix by only keeping the beginning of the version string.

Regards,

Jean-Baptiste.