### PR TITLE
Fix writing unicode strings as values with python 2.7

### DIFF
--- a/src/etcd/client.py
+++ b/src/etcd/client.py
@@ -22,6 +22,7 @@ import ssl
 import dns.resolver
 from functools import wraps
 import etcd
+from sys import version_info as python_version
 
 try:
     from urlparse import urlparse
@@ -468,7 +469,9 @@ class Client(object):
                    value, key, ttl, dir, append)
         key = self._sanitize_key(key)
         params = {}
-        if value is not None:
+        if python_version.major == 2 and isinstance(value, unicode):
+            params['value'] = value.encode('utf-8')
+        elif value is not None:
             params['value'] = value
 
         if ttl is not None:


### PR DESCRIPTION
Under python 2.7 writing unicode strings as values to etcd fails as follows:
```
import etcd
client = etcd.Client(host='127.0.0.1', port=2379)
client.write('/test/foo', u'õäö')
```
**UnicodeEncodeError: 'ascii' codec can't encode characters in position 0-2: ordinal not in range(128)**

This seems to be all that is needed to fix that.