### PR TITLE
fix DNS discovery configuration convention

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -6,7 +6,7 @@ parts = python
 develop = .
 eggs = 
      urllib3==1.22
-     pyOpenSSL==16.2
+     pyOpenSSL>=16.2
      ${deps:extraeggs}
 
 [python]

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -5,7 +5,7 @@ parts = python
       coverage
 develop = .
 eggs = 
-     urllib3==1.19.1
+     urllib3==1.22
      pyOpenSSL==16.2
      ${deps:extraeggs}
 

--- a/src/etcd/client.py
+++ b/src/etcd/client.py
@@ -220,7 +220,7 @@ class Client(object):
         self._cluster_version = version_info['etcdcluster']
 
     def _discover(self, domain):
-        srv_name = "_etcd._tcp.{}".format(domain)
+        srv_name = "_etcd-client._tcp.{}".format(domain)
         answers = dns.resolver.query(srv_name, 'SRV')
         hosts = []
         for answer in answers:


### PR DESCRIPTION
code in client.py:
def _discover(self, domain):
srv_name = "_etcd._tcp.{}".format(domain)
... ...
please refer to https://coreos.com/etcd/docs/latest/v2/clustering.html#dns-discovery
there exists two types of DNS discovery configuration convention:
like _etcd-server._tcp.example.com, _etcd-client._tcp.example.com
for etcd client, we need discovering the etcd cluster, so we use _etcd-client._tcp.example.com.
It is better that use _etcd-client._tcp.{} instead of _etcd._tcp.{}, or "_etcd-client._tcp" can be used as optional input paramter of client(i.e default prefix dns srv record is "_etcd._tcp").