### PR TITLE
Check if node is None

### DIFF
--- a/src/etcd/__init__.py
+++ b/src/etcd/__init__.py
@@ -42,7 +42,7 @@ class EtcdResult(object):
         """
         self.action = action
         for (key, default) in self._node_props.items():
-            if key in node:
+            if node and key in node:
                 setattr(self, key, node[key])
             else:
                 setattr(self, key, default)


### PR DESCRIPTION
Default value of node is None, and if thats the case an `TypeError("argument of type 'NoneType' is not iterable"` exception is raised.
Checking first if node is None, prevents this exception and doesn't start an avalanche down the mountain.

(tested agains etcd 3.4.3, with api v2 enabled)