### PR TITLE
Fix SRV format string

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -52,3 +52,4 @@ WillPlatnick
 Weizheng Xu
 WooParadog
 Wei Tie
+Zloydead

--- a/NEWS.txt
+++ b/NEWS.txt
@@ -2,6 +2,12 @@ News
 ====
 0.4.5
 -----
+*Release date: 10-Mar-2021*
+
+* Fix string format for _discovery; It never been worked.
+====
+0.4.5
+-----
 *Release date: 3-Mar-2017*
 
 * Remove dnspython2/3 requirement

--- a/NEWS.txt
+++ b/NEWS.txt
@@ -5,7 +5,8 @@ News
 *Release date: 10-Mar-2021*
 
 * Fix string format for _discovery; It never been worked.
-====
+
+
 0.4.5
 -----
 *Release date: 3-Mar-2017*

--- a/NEWS.txt
+++ b/NEWS.txt
@@ -9,6 +9,15 @@ News
 * Remove defaul value from host
 
 
+0.4.6
+-----
+*Release date: 10-Mar-2021*
+
+* Fix string format for _discovery; It never been worked.
+* Add debug to incorrected
+* Remove defaul value from host
+
+
 0.4.5
 -----
 *Release date: 3-Mar-2017*

--- a/NEWS.txt
+++ b/NEWS.txt
@@ -1,5 +1,12 @@
 News
 ====
+0.4.9
+-----
+*Release date: 10-Mar-2021*
+
+* Strip domain
+
+
 0.4.8
 -----
 *Release date: 10-Mar-2021*

--- a/NEWS.txt
+++ b/NEWS.txt
@@ -1,10 +1,12 @@
 News
 ====
-0.4.5
+0.4.6
 -----
 *Release date: 10-Mar-2021*
 
 * Fix string format for _discovery; It never been worked.
+* Add debug to incorrected
+* Remove defaul value from host
 
 
 0.4.5

--- a/NEWS.txt
+++ b/NEWS.txt
@@ -1,6 +1,13 @@
 News
 ====
-0.4.6
+0.4.8
+-----
+*Release date: 10-Mar-2021*
+
+* Host assigne correct: to self instead unused var host
+
+
+0.4.7
 -----
 *Release date: 10-Mar-2021*
 

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ README = open(os.path.join(here, 'README.rst')).read()
 NEWS = open(os.path.join(here, 'NEWS.txt')).read()
 
 
-version = '0.4.8'
+version = '0.4.9'
 
 install_requires = [
     'urllib3>=1.7.1',

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ README = open(os.path.join(here, 'README.rst')).read()
 NEWS = open(os.path.join(here, 'NEWS.txt')).read()
 
 
-version = '0.4.7'
+version = '0.4.8'
 
 install_requires = [
     'urllib3>=1.7.1',

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ test_requires = [
 ]
 
 setup(
-    name='python-etcd',
+    name='python-etcd-2',
     version=version,
     description="A python client for etcd",
     long_description=README + '\n\n' + NEWS,
@@ -35,7 +35,9 @@ setup(
     keywords='etcd raft distributed log api client',
     author='Jose Plana',
     author_email='jplana@gmail.com',
-    url='http://github.com/jplana/python-etcd',
+    maintainer='zloydead',
+    maintainer_email='me@zloz.ru',
+    url='http://github.com/zloyded/python-etcd',
     license='MIT',
     packages=find_packages('src'),
     package_dir = {'': 'src'},

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ README = open(os.path.join(here, 'README.rst')).read()
 NEWS = open(os.path.join(here, 'NEWS.txt')).read()
 
 
-version = '0.4.5'
+version = '0.4.6'
 
 install_requires = [
     'urllib3>=1.7.1',

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ README = open(os.path.join(here, 'README.rst')).read()
 NEWS = open(os.path.join(here, 'NEWS.txt')).read()
 
 
-version = '0.4.6'
+version = '0.4.7'
 
 install_requires = [
     'urllib3>=1.7.1',

--- a/src/etcd/client.py
+++ b/src/etcd/client.py
@@ -222,7 +222,7 @@ class Client(object):
         self._cluster_version = version_info['etcdcluster']
 
     def _discover(self, domain):
-        srv_name = " _etcd-client._tcp.{}".format(domain)
+        srv_name = "_etcd-client._tcp.{}".format(domain)
         _log.debug(srv_name)
         answers = dns.resolver.query(srv_name, 'SRV')
         hosts = []

--- a/src/etcd/client.py
+++ b/src/etcd/client.py
@@ -121,7 +121,7 @@ class Client(object):
         if srv_domain is not None:
             try:
                 _log.debug(srv_domain)
-                host = self._discover(srv_domain)
+                self.host = self._discover(srv_domain)
             except Exception as e:
                 _log.error("Could not discover the etcd hosts from %s: %s",
                            srv_domain, e)

--- a/src/etcd/client.py
+++ b/src/etcd/client.py
@@ -220,7 +220,7 @@ class Client(object):
         self._cluster_version = version_info['etcdcluster']
 
     def _discover(self, domain):
-        srv_name = "_etcd._tcp.{}".format(domain)
+        srv_name = " _etcd-client._tcp.{}".format(domain)
         answers = dns.resolver.query(srv_name, 'SRV')
         hosts = []
         for answer in answers:

--- a/src/etcd/client.py
+++ b/src/etcd/client.py
@@ -122,6 +122,7 @@ class Client(object):
             try:
                 _log.debug(srv_domain)
                 self.host = self._discover(srv_domain)
+                host = self.host
             except Exception as e:
                 _log.error("Could not discover the etcd hosts from %s: %s",
                            srv_domain, e)

--- a/src/etcd/client.py
+++ b/src/etcd/client.py
@@ -50,7 +50,7 @@ class Client(object):
 
     def __init__(
             self,
-            host='127.0.0.1',
+            host='',
             port=4001,
             srv_domain=None,
             version_prefix='/v2',
@@ -120,6 +120,7 @@ class Client(object):
         # If a DNS record is provided, use it to get the hosts list
         if srv_domain is not None:
             try:
+                _log.debug(srv_domain)
                 host = self._discover(srv_domain)
             except Exception as e:
                 _log.error("Could not discover the etcd hosts from %s: %s",
@@ -221,6 +222,7 @@ class Client(object):
 
     def _discover(self, domain):
         srv_name = " _etcd-client._tcp.{}".format(domain)
+        _log.debug(srv_name)
         answers = dns.resolver.query(srv_name, 'SRV')
         hosts = []
         for answer in answers:


### PR DESCRIPTION
```srv_name = "_etcd._tcp.{}".format(domain)``` is incorrect format! By the origin docs 
_etcd-server._tcp.example.com and _etcd-client._tcp.example.com