### PR TITLE
fix certificate validation bypass when cacert is not defined

### DIFF
--- a/src/etcd/client.py
+++ b/src/etcd/client.py
@@ -170,6 +170,8 @@ class Client(object):
         if ca_cert:
             kw['ca_certs'] = ca_cert
             kw['cert_reqs'] = ssl.CERT_REQUIRED
+        else:
+            kw['cert_reqs'] = ssl.CERT_NONE
 
         self.username = None
         self.password = None


### PR DESCRIPTION
Hello,

Patroni is using this library to communicate with etcd and we detected that since this [PR](https://github.com/urllib3/urllib3/pull/1507) urllib3 enable certificate validation by default so we need to manually disable it.

Thomas