### PR TITLE
disable ssl cert validation if ca_cert is not set despite new urllib3 defaults

### DIFF
--- a/src/etcd/client.py
+++ b/src/etcd/client.py
@@ -170,6 +170,9 @@ class Client(object):
         if ca_cert:
             kw['ca_certs'] = ca_cert
             kw['cert_reqs'] = ssl.CERT_REQUIRED
+        else:
+            kw['cert_reqs'] = ssl.CERT_NONE
+            urllib3.disable_warnings()
 
         self.username = None
         self.password = None


### PR DESCRIPTION
The default for ssl certificate validation was changed in urllib3, making it impossible to use the python-etcd client (and any dependent projects) with etcd clusters using self-signed certificates.

This pull request only differs from https://github.com/jplana/python-etcd/pull/280 in also disabling spamming the logs with warnings for missing ssl validation.

Ideally ssl validation would be configured independent of explicitly setting ca_cert but then changes to every piece of dependent software would be neccessary. Ideally nobody would use etcd with selt-signed certificates, but under certain circumstances the choice is only between self-signed and no ssl at all, I'd like to raise the bar for attacks to "MITM" there.