### PR TITLE
Support Python 3.13

### DIFF
--- a/src/etcd/lock.py
+++ b/src/etcd/lock.py
@@ -35,7 +35,7 @@ class Lock(object):
         old_uuid = self._uuid
         self._uuid = value
         if not self._find_lock():
-            _log.warn("The hand-set uuid was not found, refusing")
+            _log.warning("The hand-set uuid was not found, refusing")
             self._uuid = old_uuid
             raise ValueError("Inexistent UUID")
 
@@ -51,7 +51,7 @@ class Lock(object):
             self.client.read(self.lock_key)
             return True
         except etcd.EtcdKeyNotFound:
-            _log.warn("Lock was supposedly taken, but we cannot find it")
+            _log.warning("Lock was supposedly taken, but we cannot find it")
             self.is_taken = False
             return False
 


### PR DESCRIPTION
What's new in Python 3.13 states:
"logging: Remove undocumented and untested Logger.warn() and LoggerAdapter.warn() methods and logging.warn() function. Deprecated since Python 3.3, they were aliases to the logging.Logger.warning() method, logging.LoggerAdapter.warning() method and logging.warning() function. (Contributed by Victor Stinner in gh-105376.)"